### PR TITLE
Fix Windows file compatibility issue with JFileChooser

### DIFF
--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/Swing.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/Swing.kt
@@ -61,8 +61,6 @@ import javax.swing.text.Document
 import javax.swing.tree.DefaultTreeCellRenderer
 import javax.swing.tree.TreeCellRenderer
 import javax.swing.tree.TreeNode
-import kotlin.io.path.extension
-import kotlin.io.path.isDirectory
 import kotlin.reflect.KClass
 import kotlin.reflect.safeCast
 import kotlin.time.Duration.Companion.milliseconds
@@ -326,15 +324,17 @@ class ReifiedJXTable<T : TableModel>(
 
 class FileFilter(
     private val description: String,
-    private val predicate: (path: Path) -> Boolean,
+    private val predicate: (file: File) -> Boolean,
 ) : SwingFileFilter(), FileFilter {
-    constructor(description: String, extensions: List<String>) : this(description, { path -> path.extension in extensions })
+    constructor(description: String, extensions: List<String>) : this(description, { file -> file.extension in extensions })
 
     fun accept(path: Path): Boolean {
-        return path.isDirectory() || predicate(path)
+        return accept(path.toFile())
     }
 
-    override fun accept(file: File): Boolean = accept(file.toPath())
+    override fun accept(file: File): Boolean {
+        return file.isDirectory || predicate(file)
+    }
 
     override fun getDescription(): String = description
 }


### PR DESCRIPTION
Navigating to "Special" folders in Windows was breaking things, causing an `InvalidPathException` to be thrown.

After some investigation, it turns out that the `Paths` API is not compatible with these special windows folders.

Example: When creating a file referencing the "This PC" folder in windows, calling `toPath` on that file throws the exception, because the path to that file resolves to a special ID that java doesn't recognize as valid. These IDs are in the form of `::{alpha-numeric-id}`

The solution is to fall back to using `File` objects instead of paths.