### PR TITLE
Fix file/path issues with JFileSchooser and ZipView

### DIFF
--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/Swing.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/Swing.kt
@@ -63,6 +63,8 @@ import javax.swing.text.Document
 import javax.swing.tree.DefaultTreeCellRenderer
 import javax.swing.tree.TreeCellRenderer
 import javax.swing.tree.TreeNode
+import kotlin.io.path.extension
+import kotlin.io.path.isDirectory
 import kotlin.reflect.KClass
 import kotlin.reflect.safeCast
 import kotlin.time.Duration.Companion.milliseconds
@@ -326,17 +328,15 @@ class ReifiedJXTable<T : TableModel>(
 
 class FileFilter(
     private val description: String,
-    private val predicate: (file: File) -> Boolean,
+    private val predicate: (path: Path) -> Boolean,
 ) : SwingFileFilter(), FileFilter {
     constructor(description: String, extensions: List<String>) : this(description, { file -> file.extension in extensions })
 
     fun accept(path: Path): Boolean {
-        return accept(path.toFile())
+        return path.isDirectory() || predicate(path)
     }
 
-    override fun accept(file: File): Boolean {
-        return file.isDirectory || predicate(file)
-    }
+    override fun accept(file: File): Boolean = file.isDirectory() || accept(file.toPath())
 
     override fun getDescription(): String = description
 }


### PR DESCRIPTION
Addresses issue with `ZipView` being unable to convert a `ZipPath` to a `File`, and `JFileChooser` passing special Windows `File` objects oto our `FileFilter` and breaking it.

Fixes #90 