### PR TITLE
Fix for IDBs with no MDC keys causing an error.

### DIFF
--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/MDCPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/MDCPanel.kt
@@ -71,10 +71,11 @@ internal class MDCPanel(events: List<SystemLogEvent>) : FilterPanel<LogEvent>() 
         }
 
         addActionListener {
+            if (selectedItem == null) return@addActionListener
             valueCombo.model = mdcValuesPerKey.getValue(selectedItem as String).map { it.value }.let { DefaultComboBoxModel(Vector(it)) }
         }
 
-        selectedIndex = 0
+        selectedIndex = -1
     }
 
     private val addFilter = Action(


### PR DESCRIPTION
When a system logs IDB had no MDC keys, the MDC ComboBox was throwing an error, expeting data to be passed in.