### PR TITLE
Dependent preferences

### DIFF
--- a/src/main/kotlin/io/github/inductiveautomation/kindling/core/Kindling.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/core/Kindling.kt
@@ -223,6 +223,18 @@ data object Kindling {
                 },
             )
 
+            /*
+            val DependentExample = dependentPreference(
+                name = "Dependent Example",
+                description = null,
+                default = false,
+                editor = {
+                    PreferenceCheckbox("Example Boolean")
+                },
+                dependsOn = PreferenceDependency(Debug) { it },
+            )
+            */
+
             override val displayName: String = "Advanced"
             override val key: String = "advanced"
             override val preferences: List<Preference<*>> = listOf(Debug, HyperlinkStrategy)

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/core/Kindling.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/core/Kindling.kt
@@ -174,37 +174,6 @@ data object Kindling {
                 },
             )
 
-            // Can only set a string value if in dark mode
-            val ThemeExample = preference(
-                name = "Test dependent Theme",
-                default = "",
-                requiresRestart = true,
-                editor = {
-                    JXTextField("Test").apply {
-                        text = currentValue
-
-                        document.addDocumentListener(
-                            object : DocumentListener {
-                                fun onChange() {
-                                    currentValue = text
-                                }
-
-                                override fun insertUpdate(e: DocumentEvent?) = onChange()
-                                override fun removeUpdate(e: DocumentEvent?) = onChange()
-                                override fun changedUpdate(e: DocumentEvent?) = onChange()
-                            },
-                        )
-
-                        dependsOn(Theme) {
-                            isEnabled = it.isDark
-                            if (!it.isDark) {
-                                text = default
-                            }
-                        }
-                    }
-                },
-            )
-
             val ScaleFactor: Preference<Double> = preference(
                 name = "Scale Factor",
                 description = "Percentage to scale the UI.",
@@ -222,7 +191,7 @@ data object Kindling {
 
             override val displayName: String = "UI"
             override val key: String = "ui"
-            override val preferences: List<Preference<*>> = listOf(Theme, ThemeExample, ScaleFactor)
+            override val preferences: List<Preference<*>> = listOf(Theme, ScaleFactor)
         }
 
         data object Advanced : PreferenceCategory {
@@ -253,20 +222,9 @@ data object Kindling {
                 },
             )
 
-            // Checkbox can only be checked if Debug is set to true
-            val DependentExample = preference(
-                name = "Dependent Example",
-                default = false,
-                editor = {
-                    PreferenceCheckbox("Example Boolean").dependsOn(Debug) { newValue ->
-                        isEnabled = newValue
-                    }
-                },
-            )
-
             override val displayName: String = "Advanced"
             override val key: String = "advanced"
-            override val preferences: List<Preference<*>> = listOf(Debug, HyperlinkStrategy, DependentExample)
+            override val preferences: List<Preference<*>> = listOf(Debug, HyperlinkStrategy)
         }
 
         private val preferencesPath: Path = Path(System.getProperty("user.home"), ".kindling").also {

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/core/Kindling.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/core/Kindling.kt
@@ -174,6 +174,36 @@ data object Kindling {
                 },
             )
 
+            /* Can only set a string value if in dark mode
+            val ThemeExample = dependentPreference(
+                name = "Test dependent Theme",
+                default = "",
+                editor = {
+                    JXTextField("Test").apply {
+                        text = currentValue
+
+                        document.addDocumentListener(
+                            object : DocumentListener {
+                                fun onChange() {
+                                    currentValue = text
+                                }
+
+                                override fun insertUpdate(e: DocumentEvent?) = onChange()
+                                override fun removeUpdate(e: DocumentEvent?) = onChange()
+                                override fun changedUpdate(e: DocumentEvent?) = onChange()
+                            },
+                        )
+                    }
+                },
+                resetEditor = {
+                      it?.text = this.default
+                },
+                dependsOn = PreferenceDependency(Theme) {
+                    it.isDark
+                },
+            )
+             */
+
             val ScaleFactor: Preference<Double> = preference(
                 name = "Scale Factor",
                 description = "Percentage to scale the UI.",
@@ -223,7 +253,7 @@ data object Kindling {
                 },
             )
 
-            /*
+            /* Checkbox can only be checked if Debug is set to true
             val DependentExample = dependentPreference(
                 name = "Dependent Example",
                 description = null,
@@ -231,9 +261,12 @@ data object Kindling {
                 editor = {
                     PreferenceCheckbox("Example Boolean")
                 },
+                resetEditor = {
+                    it?.isSelected = this.default
+                },
                 dependsOn = PreferenceDependency(Debug) { it },
             )
-            */
+             */
 
             override val displayName: String = "Advanced"
             override val key: String = "advanced"

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/core/Kindling.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/core/Kindling.kt
@@ -156,7 +156,8 @@ data object Kindling {
 
             override val displayName: String = "General"
             override val key: String = "general"
-            override val preferences: List<Preference<*>> = listOf(HomeLocation, DefaultTool, ShowFullLoggerNames, UseHyperlinks)
+            override val preferences: List<Preference<*>> =
+                listOf(HomeLocation, DefaultTool, ShowFullLoggerNames, UseHyperlinks)
         }
 
         data object UI : PreferenceCategory {
@@ -264,7 +265,8 @@ data object Kindling {
         private val preferenceScope = CoroutineScope(Dispatchers.IO)
 
         operator fun <T : Any> set(category: PreferenceCategory, preference: Preference<T>, value: T) {
-            internalState.getOrPut(category.key) { mutableMapOf() }[preference.key] = preferencesJson.encodeToJsonElement(preference.serializer, value)
+            internalState.getOrPut(category.key) { mutableMapOf() }[preference.key] =
+                preferencesJson.encodeToJsonElement(preference.serializer, value)
             syncToDisk()
         }
 

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/core/Preferences.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/core/Preferences.kt
@@ -17,6 +17,7 @@ import javax.swing.JCheckBox
 import javax.swing.JComponent
 import javax.swing.JFrame
 import javax.swing.JPanel
+import javax.swing.SwingUtilities
 import javax.swing.UIManager
 import javax.swing.border.MatteBorder
 
@@ -27,18 +28,23 @@ interface PreferenceCategory {
     val preferences: List<Preference<*>>
 }
 
-class Preference<T : Any>(
+class PreferenceDependency<T : Any>(
+    val preference: Preference<T>,
+    val requiredValue: T,
+)
+
+open class Preference<T : Any>(
     val category: PreferenceCategory,
     val name: String,
     val description: String? = null,
     val requiresRestart: Boolean = false,
-    private val default: T,
+    protected val default: T,
     val serializer: KSerializer<T>,
     createEditor: (Preference<T>.() -> JComponent)?,
 ) {
     val key: String = name.lowercase().filter(Char::isJavaIdentifierStart)
 
-    var currentValue
+    open var currentValue
         get() = Kindling.Preferences[category, this] ?: default
         set(value) {
             Kindling.Preferences[category, this] = value
@@ -95,6 +101,78 @@ class Preference<T : Any>(
     }
 }
 
+class DependentPreference<T : Any, D : Any>(
+    category: PreferenceCategory,
+    name: String,
+    description: String? = null,
+    requiresRestart: Boolean = false,
+    default: T,
+    serializer: KSerializer<T>,
+    val dependsOn: PreferenceDependency<D>,
+    createEditor: (Preference<T>.() -> JComponent)?,
+) : Preference<T>(
+    category,
+    name,
+    description,
+    requiresRestart,
+    default,
+    serializer,
+    createEditor,
+) {
+    override var currentValue
+        get() = Kindling.Preferences[category, this] ?: default
+        set(value) {
+            Kindling.Preferences[category, this] = value
+            validate(value, dependsOn.preference.currentValue)
+            for (listener in listeners) {
+                listener(value)
+            }
+        }
+
+    init {
+        dependsOn.preference.addChangeListener {
+            validate(currentValue, it)
+        }
+
+        SwingUtilities.invokeLater { // Validate state on startup
+            validate(currentValue, dependsOn.preference.currentValue)
+            preferencesEditor.revalidate()
+        }
+    }
+
+    private fun validate(thisValue: T, otherValue: D) {
+        if (thisValue != default && otherValue != dependsOn.requiredValue) { // invalid state
+            currentValue = default
+            editor?.isEnabled = false
+        } else { // You have to stare at this for a while for it to make sense
+            editor?.isEnabled = thisValue != default || otherValue == dependsOn.requiredValue
+            dependsOn.preference.editor?.isEnabled = thisValue == default || otherValue != dependsOn.requiredValue
+        }
+    }
+
+    companion object {
+        @Suppress("unused")
+        inline fun <reified T : Any, reified D : Any> PreferenceCategory.dependentPreference(
+            name: String,
+            description: String? = null,
+            requiresRestart: Boolean = false,
+            default: T,
+            serializer: KSerializer<T> = serializer(),
+            dependsOn: PreferenceDependency<D>,
+            noinline editor: (Preference<T>.() -> JComponent)?,
+        ): DependentPreference<T, D> = DependentPreference(
+            this,
+            name,
+            description,
+            requiresRestart,
+            default,
+            serializer,
+            dependsOn,
+            editor,
+        )
+    }
+}
+
 val preferencesEditor by lazy {
     jFrame("Preferences", 600, 800, initiallyVisible = false) {
         defaultCloseOperation = JFrame.HIDE_ON_CLOSE
@@ -129,6 +207,12 @@ val preferencesEditor by lazy {
                                                 if (preference.description != null) {
                                                     add("\n")
                                                     add(preference.description)
+                                                    if (preference is DependentPreference<*, *>) {
+                                                        add(
+                                                            "Requires ${preference.dependsOn.preference.name} to be set to ${preference.dependsOn.requiredValue}.",
+                                                            "superscript",
+                                                        )
+                                                    }
                                                 }
                                             },
                                             "grow, wrap, gapy 0",


### PR DESCRIPTION
Allow a preference to depend on another. (Currently being utilized in beta Support fork)

Example: To have a boolean preference depend on the `Debug` preference being set to `true`:

```
// Checkbox can only be checked if Debug is set to true
val DependentExample = dependentPreference(
    name = "Dependent Example",
    description = null,
    default = false,
    editor = {
        PreferenceCheckbox("Example Boolean")
    },
    resetEditor = { // Necessary to revert the swing component back to its default value.
        it?.isSelected = this.default
    },
    dependsOn = PreferenceDependency(Debug) { it },
)
```

Currently, the dependent preference validates every time it changes or its dependency changes. If an invalid combination of options is detected (the dependent preference is not at its default value and the dependency predicate fails), the dependent preference it set to its default value and its editor is disabled. 

Examples included in Kindling.kt but we can remove them.