### PR TITLE
Add time extensions to context menu

### DIFF
--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/TimePanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/TimePanel.kt
@@ -28,6 +28,7 @@ import java.util.Locale
 import javax.swing.JButton
 import javax.swing.JComponent
 import javax.swing.JLabel
+import javax.swing.JMenu
 import javax.swing.JPanel
 import javax.swing.JPopupMenu
 import javax.swing.JSpinner
@@ -85,6 +86,7 @@ internal class TimePanel(
     }
 
     override fun filter(item: LogEvent): Boolean = item.timestamp in coveredRange
+
     override fun customizePopupMenu(
         menu: JPopupMenu,
         column: Column<out LogEvent, *>,
@@ -101,6 +103,30 @@ internal class TimePanel(
                     endSelector.time = event.timestamp
                 },
             )
+            menu.add(
+                JMenu("Extend").apply {
+                    timeRanges.forEach { duration ->
+                        add(
+                            Action(
+                                name = "Add $duration minutes after",
+                                description = "Extend time range to ${TimeStampFormatter.format(event.timestamp)} + $duration minutes",
+                            ) {
+                                endSelector.time = event.timestamp.plusSeconds(duration * 60L)
+                            },
+                        )
+                    }
+                    timeRanges.forEach { duration ->
+                        add(
+                            Action(
+                                name = "Add $duration minutes before",
+                                description = "Extend time range to ${TimeStampFormatter.format(event.timestamp)} - $duration minutes",
+                            ) {
+                                endSelector.time = event.timestamp.minusSeconds(duration * 60L)
+                            },
+                        )
+                    }
+                },
+            )
         }
     }
 
@@ -108,6 +134,15 @@ internal class TimePanel(
         startSelector.time = lowerBound
         endSelector.time = upperBound
         updateCoveredRange()
+    }
+
+    companion object {
+        private val timeRanges = listOf(
+            1,
+            5,
+            15,
+            30,
+        )
     }
 }
 


### PR DESCRIPTION
I don't know if I like how this actually works, but it does fulfill the stated objective. Open to some discussion on a better way to go about this. One thing that came to mind thinking about this would be if you could somehow 'capture' the time range you're currently filtered down to (via log levels, loggers, etc) and then _remove_ those other filters but keep the time range in view - I think that would make this context menu a little bit more powerful (and maybe there should also be buttons in the time panel to quickly expand your context in either direction, as well...