### PR TITLE
Present "interesting" minutes in log views, drop the minimap

### DIFF
--- a/src/main/kotlin/io/github/inductiveautomation/kindling/MainPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/MainPanel.kt
@@ -336,8 +336,8 @@ class MainPanel : JPanel(MigLayout("ins 6, fill")) {
 
                 jFrame(
                     title = "Kindling",
-                    width = 1280,
-                    height = 800,
+                    width = 1680,
+                    height = 1050,
                     embedContentIntoTitleBar = true,
                 ) {
                     defaultCloseOperation = JFrame.EXIT_ON_CLOSE

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/MainPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/MainPanel.kt
@@ -336,8 +336,8 @@ class MainPanel : JPanel(MigLayout("ins 6, fill")) {
 
                 jFrame(
                     title = "Kindling",
-                    width = 1680,
-                    height = 1050,
+                    width = 1280,
+                    height = 800,
                     embedContentIntoTitleBar = true,
                 ) {
                     defaultCloseOperation = JFrame.EXIT_ON_CLOSE

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/cache/CacheView.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/cache/CacheView.kt
@@ -440,7 +440,7 @@ object CacheViewer : Tool {
     override val title = "Cache Dump"
     override val description = "S&F Cache data/script files"
     override val icon = FlatSVGIcon("icons/bx-data.svg")
-    val extensions = listOf("data", "script", "zip")
-    override val filter = FileFilter(description, extensions)
+    internal val extensions = arrayOf("data", "script", "zip")
+    override val filter = FileFilter(description, *extensions)
     override fun open(path: Path): ToolPanel = CacheView(path)
 }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/core/ToolPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/core/ToolPanel.kt
@@ -70,7 +70,7 @@ abstract class ToolPanel(
             CSV("Comma Separated Values", "csv", TableModel::exportToCSV),
             EXCEL("Excel Workbook", "xlsx", TableModel::exportToXLSX);
 
-            val fileFilter = FileFilter(description, listOf(extension))
+            val fileFilter = FileFilter(description, extension)
         }
     }
 }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/gatewaynetwork/GatewayNetworkViewer.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/gatewaynetwork/GatewayNetworkViewer.kt
@@ -137,7 +137,7 @@ object GatewayNetworkTool : ClipboardTool {
     override val title = "Gateway Network Diagram"
     override val description = "Gateway network diagram (.json or .txt) files"
     override val icon = FlatSVGIcon("icons/bx-sitemap.svg")
-    override val filter = FileFilter(description, listOf("json", "txt"))
+    override val filter = FileFilter(description, "json", "txt")
 
     override fun open(data: String): ToolPanel {
         return GatewayNetworkViewer(

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/idb/IdbView.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/idb/IdbView.kt
@@ -173,6 +173,6 @@ object IdbViewer : Tool {
     override val title = "Idb File"
     override val description = ".idb (SQLite3) files"
     override val icon = FlatSVGIcon("icons/bx-hdd.svg")
-    override val filter = FileFilter(description, listOf("idb"))
+    override val filter = FileFilter(description, "idb")
     override fun open(path: Path): ToolPanel = IdbView(path)
 }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/idb/generic/GenericView.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/idb/generic/GenericView.kt
@@ -5,6 +5,7 @@ import com.jidesoft.comparator.AlphanumComparator
 import io.github.inductiveautomation.kindling.core.Kindling
 import io.github.inductiveautomation.kindling.core.ToolPanel
 import io.github.inductiveautomation.kindling.utils.Action
+import io.github.inductiveautomation.kindling.utils.ButtonPanel
 import io.github.inductiveautomation.kindling.utils.FlatScrollPane
 import io.github.inductiveautomation.kindling.utils.HorizontalSplitPane
 import io.github.inductiveautomation.kindling.utils.VerticalSplitPane
@@ -115,12 +116,7 @@ class SortableTree(val tables: List<Table>) {
 
     private val sortButtons = createSortButtons()
 
-    val component = JPanel(MigLayout("ins 0, fill")).apply {
-        val sortGroupEnumeration = sortButtons.elements
-        add(sortGroupEnumeration.nextElement(), "split ${sortButtons.buttonCount}, flowx")
-        for (element in sortGroupEnumeration) {
-            add(element, "gapx 2")
-        }
+    val component = ButtonPanel(sortButtons).apply {
         add(FlatScrollPane(tree), "newline, push, grow")
     }
 }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/LogPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/LogPanel.kt
@@ -311,7 +311,7 @@ class LogPanel(
         }
     }
 
-    private class Header(private val totalRows: Int) : JPanel(MigLayout("ins 0, fill, hidemode 3")) {
+    private class Header(private val totalRows: Int) : JPanel(MigLayout("ins 2, fill, hidemode 3")) {
         private val events = JLabel("Showing $totalRows of $totalRows events")
 
         val search = JXSearchField("Search")

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/MDCPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/MDCPanel.kt
@@ -122,7 +122,7 @@ internal class MDCPanel(events: List<SystemLogEvent>) : FilterPanel<LogEvent>() 
         }
     }
 
-    override val component = JPanel(MigLayout("ins 0, fill"))
+    override val component = JPanel(MigLayout("ins 2 0, fill"))
 
     init {
         component.apply {

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/NamePanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/NamePanel.kt
@@ -5,9 +5,14 @@ import io.github.inductiveautomation.kindling.utils.Action
 import io.github.inductiveautomation.kindling.utils.Column
 import io.github.inductiveautomation.kindling.utils.FilterListPanel
 import io.github.inductiveautomation.kindling.utils.FilterModel
+import io.github.inductiveautomation.kindling.utils.PopupMenuCustomizer
+import java.awt.event.ItemEvent
+import javax.swing.JCheckBoxMenuItem
 import javax.swing.JPopupMenu
 
-internal class NamePanel(events: List<LogEvent>) : FilterListPanel<LogEvent>("Logger", ::getSortKey) {
+internal class NamePanel(
+    events: List<LogEvent>,
+) : FilterListPanel<LogEvent>("Logger", ::getSortKey), PopupMenuCustomizer {
     init {
         filterList.setModel(FilterModel(events.groupingBy(LogEvent::logger).eachCount(), ::getSortKey))
         filterList.selectAll()
@@ -19,6 +24,7 @@ internal class NamePanel(events: List<LogEvent>) : FilterListPanel<LogEvent>("Lo
 
     override fun filter(item: LogEvent) = item.logger in filterList.checkBoxListSelectedValues
 
+    // customize the popup menu on the primary log panel table
     override fun customizePopupMenu(
         menu: JPopupMenu,
         column: Column<out LogEvent, *>,
@@ -38,6 +44,17 @@ internal class NamePanel(events: List<LogEvent>) : FilterListPanel<LogEvent>("Lo
                 },
             )
         }
+    }
+
+    // customize the popup menu above our own entry in the tab strip
+    override fun customizePopupMenu(menu: JPopupMenu) {
+        menu.add(
+            JCheckBoxMenuItem("Show full logger names", ShowFullLoggerNames.currentValue).apply {
+                addItemListener { e ->
+                    ShowFullLoggerNames.currentValue = e.stateChange == ItemEvent.SELECTED
+                }
+            },
+        )
     }
 
     companion object {

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/TableModel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/TableModel.kt
@@ -7,6 +7,7 @@ import io.github.inductiveautomation.kindling.log.LogViewer.TimeStampFormatter
 import io.github.inductiveautomation.kindling.utils.Column
 import io.github.inductiveautomation.kindling.utils.ColumnList
 import io.github.inductiveautomation.kindling.utils.ReifiedLabelProvider
+import io.github.inductiveautomation.kindling.utils.StringProvider
 import org.jdesktop.swingx.renderer.DefaultTableRenderer
 import org.jdesktop.swingx.renderer.StringValues
 import java.time.Instant
@@ -105,7 +106,7 @@ sealed class LogColumnList<T : LogEvent> : ColumnList<T>() {
         columnCustomization = {
             minWidth = 50
 
-            val valueExtractor: (String?) -> String? = {
+            val valueExtractor: StringProvider<String> = {
                 if (ShowFullLoggerNames.currentValue) {
                     it
                 } else {

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/WrapperLogView.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/WrapperLogView.kt
@@ -6,7 +6,6 @@ import io.github.inductiveautomation.kindling.core.ClipboardTool
 import io.github.inductiveautomation.kindling.core.Kindling.Preferences.General.DefaultEncoding
 import io.github.inductiveautomation.kindling.core.MultiTool
 import io.github.inductiveautomation.kindling.core.Preference
-import io.github.inductiveautomation.kindling.core.Preference.Companion.PreferenceCheckbox
 import io.github.inductiveautomation.kindling.core.Preference.Companion.preference
 import io.github.inductiveautomation.kindling.core.PreferenceCategory
 import io.github.inductiveautomation.kindling.core.ToolPanel
@@ -190,15 +189,7 @@ data object LogViewer : MultiTool, ClipboardTool, PreferenceCategory {
             return _formatter
         }
 
-    val ShowDensity = preference(
-        name = "Density Display",
-        default = true,
-        editor = {
-            PreferenceCheckbox("Show 'minimap' of log events in scrollbar")
-        },
-    )
-
     override val displayName: String = "Log View"
     override val key: String = "logview"
-    override val preferences: List<Preference<*>> = listOf(SelectedTimeZone, ShowDensity)
+    override val preferences: List<Preference<*>> = listOf(SelectedTimeZone)
 }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/thread/MultiThreadView.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/thread/MultiThreadView.kt
@@ -32,6 +32,7 @@ import io.github.inductiveautomation.kindling.utils.ReifiedJXTable
 import io.github.inductiveautomation.kindling.utils.VerticalSplitPane
 import io.github.inductiveautomation.kindling.utils.attachPopupMenu
 import io.github.inductiveautomation.kindling.utils.escapeHtml
+import io.github.inductiveautomation.kindling.utils.rowIndices
 import io.github.inductiveautomation.kindling.utils.selectedRowIndices
 import io.github.inductiveautomation.kindling.utils.toBodyLine
 import io.github.inductiveautomation.kindling.utils.transferTo
@@ -369,7 +370,7 @@ class MultiThreadView(
         }
 
         comparison.addBlockerSelectedListener { selectedID ->
-            for (i in 0 until mainTable.model.rowCount) {
+            for (i in mainTable.model.rowIndices) {
                 if (selectedID == mainTable.model[i, mainTable.model.columns.id]) {
                     val rowIndex = mainTable.convertRowIndexToView(i)
                     mainTable.selectionModel.setSelectionInterval(0, rowIndex)
@@ -473,7 +474,7 @@ data object MultiThreadViewer : MultiTool, ClipboardTool, PreferenceCategory {
     override val title = "Thread Viewer"
     override val description = "Thread dump (.json or .txt) files"
     override val icon = FlatSVGIcon("icons/bx-file.svg")
-    override val filter = FileFilter(description, listOf("json", "txt"))
+    override val filter = FileFilter(description, "json", "txt")
 
     override val respectsEncoding: Boolean = true
     override fun open(path: Path): ToolPanel = open(listOf(path))

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/thread/MultiThreadView.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/thread/MultiThreadView.kt
@@ -69,12 +69,6 @@ class MultiThreadView(
     private val statePanel = StatePanel()
     private val searchField = JXSearchField("Search")
 
-    private val sidebar = FilterSidebar(
-        statePanel,
-        systemPanel,
-        poolPanel,
-    )
-
     private var visibleThreadDumps: List<ThreadDump?> = emptyList()
         set(value) {
             field = value
@@ -224,6 +218,12 @@ class MultiThreadView(
             }
         }
     }
+
+    private val sidebar = FilterSidebar(
+        statePanel,
+        systemPanel,
+        poolPanel,
+    )
 
     private var comparison = ThreadComparisonPane(threadDumps.size, threadDumps[0].version)
 

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/Components.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/Components.kt
@@ -1,0 +1,104 @@
+package io.github.inductiveautomation.kindling.utils
+
+import com.formdev.flatlaf.extras.components.FlatScrollPane
+import com.formdev.flatlaf.util.SystemInfo
+import com.jidesoft.swing.StyledLabel
+import com.jidesoft.swing.StyledLabelBuilder
+import io.github.inductiveautomation.kindling.core.Kindling
+import net.miginfocom.swing.MigLayout
+import java.awt.Component
+import javax.swing.ButtonGroup
+import javax.swing.JFrame
+import javax.swing.JPanel
+import javax.swing.JSplitPane
+import javax.swing.SwingConstants
+import javax.swing.border.EmptyBorder
+
+inline fun FlatScrollPane(
+    component: Component,
+    block: FlatScrollPane.() -> Unit = {},
+) = FlatScrollPane().apply {
+    setViewportView(component)
+    block(this)
+}
+
+/**
+ * Constructs and (optionally) immediately displays a JFrame of the given dimensions, centered on the screen.
+ */
+inline fun jFrame(
+    title: String,
+    width: Int,
+    height: Int,
+    initiallyVisible: Boolean = true,
+    embedContentIntoTitleBar: Boolean = false,
+    block: JFrame.() -> Unit,
+) = JFrame(title).apply {
+    setSize(width, height)
+
+    if (embedContentIntoTitleBar && SystemInfo.isMacFullWindowContentSupported) {
+        rootPane.putClientProperty("apple.awt.windowTitleVisible", false)
+        rootPane.putClientProperty("apple.awt.fullWindowContent", true)
+        rootPane.putClientProperty("apple.awt.transparentTitleBar", true)
+    }
+
+    iconImages = Kindling.frameIcons
+    defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
+
+    setLocationRelativeTo(null)
+
+    block()
+
+    isVisible = initiallyVisible
+}
+
+inline fun StyledLabel(block: StyledLabelBuilder.() -> Unit): StyledLabel {
+    return StyledLabelBuilder().apply(block).createLabel()
+}
+
+inline fun StyledLabel.style(block: StyledLabelBuilder.() -> Unit) {
+    StyledLabelBuilder().apply {
+        block()
+        clearStyleRanges()
+        configure(this@style)
+    }
+}
+
+fun EmptyBorder(): EmptyBorder = EmptyBorder(0, 0, 0, 0)
+
+@Suppress("FunctionName")
+fun HorizontalSplitPane(
+    left: Component,
+    right: Component,
+    resizeWeight: Double = 0.5,
+    block: JSplitPane.() -> Unit = {},
+) = JSplitPane(SwingConstants.VERTICAL, left, right).apply {
+    isOneTouchExpandable = true
+    this.resizeWeight = resizeWeight
+
+    block()
+}
+
+@Suppress("FunctionName")
+fun VerticalSplitPane(
+    top: Component,
+    bottom: Component,
+    resizeWeight: Double = 0.5,
+    block: JSplitPane.() -> Unit = {},
+) = JSplitPane(SwingConstants.HORIZONTAL, top, bottom).apply {
+    isOneTouchExpandable = true
+    this.resizeWeight = resizeWeight
+
+    block()
+}
+
+/**
+ * Constructs a MigLayout JPanel containing each element of [group] in the first row.
+ */
+@Suppress("FunctionName")
+fun ButtonPanel(group: ButtonGroup) = JPanel(MigLayout("ins 2 0, fill")).apply {
+    val sortGroupEnumeration = group.elements
+    add(sortGroupEnumeration.nextElement(), "split ${group.buttonCount}, flowx")
+    for (element in sortGroupEnumeration) {
+        add(element, "gapx 2")
+    }
+}

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/FileFilter.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/FileFilter.kt
@@ -1,0 +1,30 @@
+package io.github.inductiveautomation.kindling.utils
+
+import java.io.File
+import java.nio.file.Path
+import kotlin.io.path.extension
+import kotlin.io.path.isDirectory
+import java.io.FileFilter as IoFileFilter
+import javax.swing.filechooser.FileFilter as SwingFileFilter
+
+/**
+ * A unified abstraction over the [java.io.FileFilter][IoFileFilter] interface and the Swing
+ * [filechooser.FileFilter][SwingFileFilter] abstract class.
+ */
+class FileFilter(
+    private val description: String,
+    private val predicate: (path: Path) -> Boolean,
+) : SwingFileFilter(), IoFileFilter {
+    constructor(description: String, vararg extensions: String) : this(
+        description,
+        { path -> path.extension.lowercase() in extensions },
+    )
+
+    fun accept(path: Path): Boolean {
+        return path.isDirectory() || predicate(path)
+    }
+
+    override fun accept(file: File): Boolean = file.isDirectory() || accept(file.toPath())
+
+    override fun getDescription(): String = description
+}

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/FilterListPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/FilterListPanel.kt
@@ -2,8 +2,6 @@ package io.github.inductiveautomation.kindling.utils
 
 import io.github.inductiveautomation.kindling.core.FilterChangeListener
 import io.github.inductiveautomation.kindling.core.FilterPanel
-import net.miginfocom.swing.MigLayout
-import javax.swing.JPanel
 import javax.swing.JPopupMenu
 
 abstract class FilterListPanel<T>(
@@ -14,12 +12,7 @@ abstract class FilterListPanel<T>(
 
     private val sortButtons = filterList.createSortButtons()
 
-    override val component = JPanel(MigLayout("ins 0, fill")).apply {
-        val sortGroupEnumeration = sortButtons.elements
-        add(sortGroupEnumeration.nextElement(), "split ${sortButtons.buttonCount}, flowx")
-        for (element in sortGroupEnumeration) {
-            add(element, "gapx 2")
-        }
+    override val component = ButtonPanel(sortButtons).apply {
         add(FlatScrollPane(filterList), "newline, push, grow")
     }
 

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/FilterSidebar.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/FilterSidebar.kt
@@ -35,11 +35,16 @@ class FilterSidebar<T>(
             if (tabIndex == -1) return@attachPopupMenu null
 
             JPopupMenu().apply {
+                val filterPanel = filterPanels[tabIndex]
+
                 add(
                     Action("Reset") {
-                        filterPanels[tabIndex].reset()
+                        filterPanel.reset()
                     },
                 )
+                if (filterPanel is PopupMenuCustomizer) {
+                    filterPanel.customizePopupMenu(this)
+                }
             }
         }
 

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/FilterSidebar.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/FilterSidebar.kt
@@ -15,7 +15,7 @@ class FilterSidebar<T>(
         tabLayoutPolicy = SCROLL_TAB_LAYOUT
         tabsPopupPolicy = TabsPopupPolicy.asNeeded
         scrollButtonsPolicy = ScrollButtonsPolicy.never
-        tabWidthMode = TabWidthMode.equal
+        tabWidthMode = TabWidthMode.compact
         tabType = TabType.underlined
         tabHeight = 16
 

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/NoSelectionModel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/NoSelectionModel.kt
@@ -1,0 +1,24 @@
+package io.github.inductiveautomation.kindling.utils
+
+import javax.swing.DefaultListSelectionModel
+import javax.swing.ListSelectionModel
+
+/**
+ * A simple [ListSelectionModel] implementation that never allows selecting any elements.
+ */
+class NoSelectionModel : DefaultListSelectionModel() {
+    override fun setSelectionInterval(index0: Int, index1: Int) = Unit
+    override fun addSelectionInterval(index0: Int, index1: Int) = Unit
+    override fun removeSelectionInterval(index0: Int, index1: Int) = Unit
+    override fun getMinSelectionIndex(): Int = -1
+    override fun getMaxSelectionIndex(): Int = -1
+    override fun isSelectedIndex(index: Int): Boolean = false
+    override fun getAnchorSelectionIndex(): Int = -1
+    override fun setAnchorSelectionIndex(index: Int) = Unit
+    override fun getLeadSelectionIndex(): Int = -1
+    override fun setLeadSelectionIndex(index: Int) = Unit
+    override fun clearSelection() = Unit
+    override fun isSelectionEmpty(): Boolean = true
+    override fun insertIndexInterval(index: Int, length: Int, before: Boolean) = Unit
+    override fun removeIndexInterval(index0: Int, index1: Int) = Unit
+}

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/ReifiedJXTable.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/ReifiedJXTable.kt
@@ -1,0 +1,103 @@
+package io.github.inductiveautomation.kindling.utils
+
+import com.formdev.flatlaf.extras.FlatSVGIcon
+import io.github.inductiveautomation.kindling.utils.ReifiedLabelProvider.Companion.setDefaultRenderer
+import org.jdesktop.swingx.JXTable
+import org.jdesktop.swingx.decorator.ColorHighlighter
+import org.jdesktop.swingx.decorator.HighlightPredicate
+import org.jdesktop.swingx.sort.SortController
+import org.jdesktop.swingx.table.ColumnControlButton
+import java.awt.Color
+import javax.swing.JComponent
+import javax.swing.SortOrder
+import javax.swing.UIManager
+import javax.swing.table.TableModel
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * An implementation of JXTable that is specifically assigned a model class on construction and is guaranteed to always
+ * contain an instance of that model class. Generally, use the standalone reified [ReifiedJXTable] function as a
+ * pseudo-constructor.
+ */
+class ReifiedJXTable<T : TableModel>(
+    model: T,
+    private val modelClass: Class<T>,
+    columns: ColumnList<*>?,
+) : JXTable(model) {
+    private val setup = true
+
+    private val packLater: () -> Unit = debounce(
+        waitTime = 500.milliseconds,
+        coroutineScope = EDT_SCOPE,
+        destinationFunction = ::packAll,
+    )
+
+    init {
+        if (columns != null) {
+            columnFactory = columns.toColumnFactory()
+            createDefaultColumnsFromModel()
+        }
+        isColumnControlVisible = true
+
+        setDefaultRenderer<String>(
+            getText = { it },
+            getTooltip = { it },
+        )
+
+        setSortOrderCycle(SortOrder.ASCENDING, SortOrder.DESCENDING, SortOrder.UNSORTED)
+
+        // TODO header name as tooltip without breaking sorting
+
+        addHighlighter(
+            object : ColorHighlighter(HighlightPredicate.ODD) {
+                override fun getBackground(): Color? = UIManager.getColor("UIColorHighlighter.stripingBackground")
+            },
+        )
+
+        packLater()
+        actionMap.remove("find")
+    }
+
+    override fun createDefaultColumnControl(): JComponent {
+        return ColumnControlButton(this, FlatSVGIcon("icons/bx-column.svg").derive(0.8F))
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun getModel(): T = super.getModel() as T
+
+    override fun setModel(model: TableModel) {
+        if (setup) { // not sure why this is required, something with Kotlin's late initialization
+            require(model::class.java == modelClass) { "Expected $modelClass but got ${model::class.java}" }
+        }
+        val sortedColumn = sortedColumnIndex
+        val sortedColumnIsVisible = convertColumnIndexToView(sortedColumn) != -1
+
+        val sortOrder = if (sortedColumn >= 0) (rowSorter as SortController<*>).getSortOrder(sortedColumn) else null
+
+        val previousColumnSizes = IntArray(columnCount) { i ->
+            getColumnExt(i).preferredWidth
+        }
+
+        super.setModel(model)
+
+        if (sortOrder != null && sortedColumnIsVisible) {
+            setSortOrder(sortedColumn, sortOrder)
+        }
+        if (setup) {
+            for (index in model.columnIndices) {
+                val previousSize = previousColumnSizes.getOrNull(index)
+                if (previousSize != null) {
+                    getColumnExt(index).preferredWidth = previousSize
+                }
+            }
+            packLater()
+        }
+    }
+}
+
+inline fun <reified T : TableModel> ReifiedJXTable(
+    model: T,
+    columns: ColumnList<*>? = null,
+): ReifiedJXTable<T> {
+    return ReifiedJXTable(model, T::class.java, columns)
+}

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/Renderers.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/Renderers.kt
@@ -1,0 +1,135 @@
+package io.github.inductiveautomation.kindling.utils
+
+import com.formdev.flatlaf.extras.FlatSVGIcon
+import org.jdesktop.swingx.JXTable
+import org.jdesktop.swingx.renderer.CellContext
+import org.jdesktop.swingx.renderer.ComponentProvider
+import org.jdesktop.swingx.renderer.DefaultTableRenderer
+import org.jdesktop.swingx.renderer.JRendererLabel
+import java.awt.Component
+import javax.swing.DefaultListCellRenderer
+import javax.swing.Icon
+import javax.swing.JComboBox
+import javax.swing.JLabel
+import javax.swing.JList
+import javax.swing.JTree
+import javax.swing.ListCellRenderer
+import javax.swing.plaf.basic.BasicComboBoxRenderer
+import javax.swing.tree.DefaultTreeCellRenderer
+import javax.swing.tree.TreeCellRenderer
+import kotlin.reflect.KClass
+import kotlin.reflect.safeCast
+
+typealias StringProvider<T> = (T?) -> String?
+typealias IconProvider<T> = (T?) -> Icon?
+
+class ReifiedLabelProvider<T : Any>(
+    private val valueClass: KClass<T>,
+    private val getText: StringProvider<T>,
+    private val getIcon: IconProvider<T>,
+    private val getTooltip: StringProvider<T>,
+) : ComponentProvider<JLabel>() {
+    override fun createRendererComponent(): JLabel = JRendererLabel()
+
+    override fun configureState(context: CellContext) {
+        // TODO - Color icon when selected
+        rendererComponent.horizontalAlignment = horizontalAlignment
+    }
+
+    override fun format(context: CellContext) {
+        rendererComponent.apply {
+            val value = valueClass.safeCast(context.value)
+            text = getText(value)
+            icon = getIcon(value)
+            toolTipText = getTooltip(value)
+        }
+    }
+
+    companion object {
+        private val NULL_ICON = FlatSVGIcon("icons/null.svg")
+
+        fun <T> defaultIconFunction(): IconProvider<T> = {
+            if (it == null) {
+                NULL_ICON
+            } else {
+                null
+            }
+        }
+
+        inline operator fun <reified T : Any> invoke(
+            noinline getText: StringProvider<T>,
+            noinline getIcon: IconProvider<T> = defaultIconFunction(),
+            noinline getTooltip: StringProvider<T> = { null },
+        ): ReifiedLabelProvider<T> {
+            return ReifiedLabelProvider(T::class, getText, getIcon, getTooltip)
+        }
+
+        inline fun <reified T : Any> JXTable.setDefaultRenderer(
+            noinline getText: StringProvider<T>,
+            noinline getIcon: IconProvider<T> = defaultIconFunction(),
+            noinline getTooltip: StringProvider<T> = { null },
+        ) {
+            this.setDefaultRenderer(
+                T::class.java,
+                DefaultTableRenderer(ReifiedLabelProvider(getText, getIcon, getTooltip)),
+            )
+        }
+    }
+}
+
+inline fun <reified T> listCellRenderer(crossinline customize: JLabel.(list: JList<*>, value: T, index: Int, selected: Boolean, focused: Boolean) -> Unit): ListCellRenderer<Any> {
+    return object : DefaultListCellRenderer() {
+        override fun getListCellRendererComponent(
+            list: JList<*>,
+            value: Any?,
+            index: Int,
+            selected: Boolean,
+            focused: Boolean,
+        ): Component {
+            return super.getListCellRendererComponent(list, value, index, selected, focused).apply {
+                try {
+                    if (value is T) {
+                        customize.invoke(this as JLabel, list, value, index, selected, focused)
+                    }
+                } catch (e: Exception) {
+                    e.printStackTrace()
+                }
+            }
+        }
+    }
+}
+
+fun treeCellRenderer(customize: JLabel.(tree: JTree, value: Any?, selected: Boolean, expanded: Boolean, leaf: Boolean, row: Int, hasFocus: Boolean) -> Component): TreeCellRenderer {
+    return object : DefaultTreeCellRenderer() {
+        override fun getTreeCellRendererComponent(
+            tree: JTree,
+            value: Any?,
+            sel: Boolean,
+            expanded: Boolean,
+            leaf: Boolean,
+            row: Int,
+            hasFocus: Boolean,
+        ): Component {
+            val soup = super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus)
+            return customize.invoke(soup as JLabel, tree, value, sel, expanded, leaf, row, hasFocus)
+        }
+    }
+}
+
+inline fun <reified T> JComboBox<T>.configureCellRenderer(
+    noinline block: BasicComboBoxRenderer.(list: JList<*>, value: T?, index: Int, isSelected: Boolean, cellHasFocus: Boolean) -> Unit,
+) {
+    renderer = object : BasicComboBoxRenderer() {
+        override fun getListCellRendererComponent(
+            list: JList<*>,
+            value: Any?,
+            index: Int,
+            isSelected: Boolean,
+            cellHasFocus: Boolean,
+        ): Component {
+            super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus)
+            block(list, value as T?, index, isSelected, cellHasFocus)
+            return this
+        }
+    }
+}

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/Swing.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/Swing.kt
@@ -54,6 +54,7 @@ import javax.swing.SortOrder.ASCENDING
 import javax.swing.SortOrder.DESCENDING
 import javax.swing.SortOrder.UNSORTED
 import javax.swing.SwingConstants
+import javax.swing.SwingUtilities
 import javax.swing.UIManager
 import javax.swing.border.EmptyBorder
 import javax.swing.event.EventListenerList
@@ -533,4 +534,8 @@ fun VerticalSplitPane(
     this.resizeWeight = resizeWeight
 
     block()
+}
+
+inline fun <reified C> Component.getAncestorOfClass(): C? {
+    return SwingUtilities.getAncestorOfClass(C::class.java, this) as? C
 }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/Swing.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/Swing.kt
@@ -1,27 +1,11 @@
 package io.github.inductiveautomation.kindling.utils
 
 import com.formdev.flatlaf.extras.FlatSVGIcon
-import com.formdev.flatlaf.extras.components.FlatScrollPane
-import com.formdev.flatlaf.util.SystemInfo
 import com.github.weisj.jsvg.SVGDocument
 import com.github.weisj.jsvg.attributes.ViewBox
-import com.jidesoft.swing.StyledLabel
-import com.jidesoft.swing.StyledLabelBuilder
-import io.github.evanrupert.excelkt.workbook
-import io.github.inductiveautomation.kindling.core.Kindling.frameIcons
-import io.github.inductiveautomation.kindling.utils.ReifiedLabelProvider.Companion.setDefaultRenderer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.swing.Swing
-import org.jdesktop.swingx.JXTable
-import org.jdesktop.swingx.decorator.ColorHighlighter
-import org.jdesktop.swingx.decorator.HighlightPredicate
-import org.jdesktop.swingx.renderer.CellContext
-import org.jdesktop.swingx.renderer.ComponentProvider
-import org.jdesktop.swingx.renderer.DefaultTableRenderer
-import org.jdesktop.swingx.renderer.JRendererLabel
-import org.jdesktop.swingx.sort.SortController
-import org.jdesktop.swingx.table.ColumnControlButton
 import java.awt.Color
 import java.awt.Component
 import java.awt.Container
@@ -31,171 +15,23 @@ import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import java.awt.image.BufferedImage
 import java.io.File
-import java.io.FileFilter
-import java.nio.file.Path
-import java.util.Collections
-import java.util.Enumeration
 import java.util.EventListener
-import javax.swing.DefaultListCellRenderer
-import javax.swing.DefaultListSelectionModel
-import javax.swing.Icon
-import javax.swing.JComboBox
 import javax.swing.JComponent
 import javax.swing.JFileChooser
-import javax.swing.JFrame
-import javax.swing.JLabel
-import javax.swing.JList
 import javax.swing.JPopupMenu
-import javax.swing.JSplitPane
-import javax.swing.JTable
-import javax.swing.JTree
-import javax.swing.ListCellRenderer
-import javax.swing.SortOrder.ASCENDING
-import javax.swing.SortOrder.DESCENDING
-import javax.swing.SortOrder.UNSORTED
-import javax.swing.SwingConstants
 import javax.swing.SwingUtilities
-import javax.swing.UIManager
-import javax.swing.border.EmptyBorder
 import javax.swing.event.EventListenerList
-import javax.swing.plaf.basic.BasicComboBoxRenderer
-import javax.swing.table.TableModel
 import javax.swing.text.Document
-import javax.swing.tree.DefaultTreeCellRenderer
-import javax.swing.tree.TreeCellRenderer
-import javax.swing.tree.TreeNode
-import kotlin.io.path.extension
-import kotlin.io.path.isDirectory
-import kotlin.reflect.KClass
-import kotlin.reflect.safeCast
-import kotlin.time.Duration.Companion.milliseconds
-import javax.swing.filechooser.FileFilter as SwingFileFilter
-
-typealias StringProvider<T> = (T?) -> String?
-typealias IconProvider<T> = (T?) -> Icon?
-
-class ReifiedLabelProvider<T : Any>(
-    private val valueClass: KClass<T>,
-    private val getText: StringProvider<T>,
-    private val getIcon: IconProvider<T>,
-    private val getTooltip: StringProvider<T>,
-) : ComponentProvider<JLabel>() {
-    override fun createRendererComponent(): JLabel = JRendererLabel()
-
-    override fun configureState(context: CellContext) {
-        // TODO - Color icon when selected
-        rendererComponent.horizontalAlignment = horizontalAlignment
-    }
-
-    override fun format(context: CellContext) {
-        rendererComponent.apply {
-            val value = valueClass.safeCast(context.value)
-            text = getText(value)
-            icon = getIcon(value)
-            toolTipText = getTooltip(value)
-        }
-    }
-
-    companion object {
-        private val NULL_ICON = FlatSVGIcon("icons/null.svg")
-
-        fun <T> defaultIconFunction(): IconProvider<T> = {
-            if (it == null) {
-                NULL_ICON
-            } else {
-                null
-            }
-        }
-
-        inline operator fun <reified T : Any> invoke(
-            noinline getText: StringProvider<T>,
-            noinline getIcon: IconProvider<T> = defaultIconFunction(),
-            noinline getTooltip: StringProvider<T> = { null },
-        ): ReifiedLabelProvider<T> {
-            return ReifiedLabelProvider(T::class, getText, getIcon, getTooltip)
-        }
-
-        inline fun <reified T : Any> JXTable.setDefaultRenderer(
-            noinline getText: StringProvider<T>,
-            noinline getIcon: IconProvider<T> = defaultIconFunction(),
-            noinline getTooltip: StringProvider<T> = { null },
-        ) {
-            this.setDefaultRenderer(
-                T::class.java,
-                DefaultTableRenderer(ReifiedLabelProvider(getText, getIcon, getTooltip)),
-            )
-        }
-    }
-}
-
-fun JTable.selectedRowIndices(): IntArray {
-    return selectionModel.selectedIndices
-        .filter { isRowSelected(it) }
-        .map { convertRowIndexToModel(it) }
-        .toIntArray()
-}
-
-fun JTable.selectedOrAllRowIndices(): IntArray {
-    return if (selectionModel.isSelectionEmpty) {
-        IntArray(model.rowCount) { it }
-    } else {
-        selectedRowIndices()
-    }
-}
-
-inline fun <reified T> listCellRenderer(crossinline customize: JLabel.(list: JList<*>, value: T, index: Int, selected: Boolean, focused: Boolean) -> Unit): ListCellRenderer<Any> {
-    return object : DefaultListCellRenderer() {
-        override fun getListCellRendererComponent(
-            list: JList<*>,
-            value: Any?,
-            index: Int,
-            selected: Boolean,
-            focused: Boolean,
-        ): Component {
-            return super.getListCellRendererComponent(list, value, index, selected, focused).apply {
-                try {
-                    if (value is T) {
-                        customize.invoke(this as JLabel, list, value, index, selected, focused)
-                    }
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                }
-            }
-        }
-    }
-}
-
-fun treeCellRenderer(customize: JLabel.(tree: JTree, value: Any?, selected: Boolean, expanded: Boolean, leaf: Boolean, row: Int, hasFocus: Boolean) -> Component): TreeCellRenderer {
-    return object : DefaultTreeCellRenderer() {
-        override fun getTreeCellRendererComponent(
-            tree: JTree,
-            value: Any?,
-            sel: Boolean,
-            expanded: Boolean,
-            leaf: Boolean,
-            row: Int,
-            hasFocus: Boolean,
-        ): Component {
-            val soup = super.getTreeCellRendererComponent(tree, value, sel, expanded, leaf, row, hasFocus)
-            return customize.invoke(soup as JLabel, tree, value, sel, expanded, leaf, row, hasFocus)
-        }
-    }
-}
-
-inline fun FlatScrollPane(component: Component, block: FlatScrollPane.() -> Unit = {}): FlatScrollPane {
-    return FlatScrollPane().apply {
-        setViewportView(component)
-        block(this)
-    }
-}
-
-val Document.text: String
-    get() = getText(0, length)
 
 /**
  * A common CoroutineScope bound to the event dispatch thread (see [Dispatchers.Swing]).
  */
 val EDT_SCOPE by lazy { CoroutineScope(Dispatchers.Swing) }
+
+val menuShortcutKeyMaskEx = Toolkit.getDefaultToolkit().menuShortcutKeyMaskEx
+
+val Document.text: String
+    get() = getText(0, length)
 
 inline fun <T : Component> T.attachPopupMenu(
     crossinline menuFn: T.(event: MouseEvent) -> JPopupMenu?,
@@ -226,123 +62,6 @@ fun FlatSVGIcon.derive(colorer: (Color) -> Color): FlatSVGIcon {
     }
 }
 
-class NoSelectionModel : DefaultListSelectionModel() {
-    override fun setSelectionInterval(index0: Int, index1: Int) = Unit
-    override fun addSelectionInterval(index0: Int, index1: Int) = Unit
-    override fun removeSelectionInterval(index0: Int, index1: Int) = Unit
-    override fun getMinSelectionIndex(): Int = -1
-    override fun getMaxSelectionIndex(): Int = -1
-    override fun isSelectedIndex(index: Int): Boolean = false
-    override fun getAnchorSelectionIndex(): Int = -1
-    override fun setAnchorSelectionIndex(index: Int) = Unit
-    override fun getLeadSelectionIndex(): Int = -1
-    override fun setLeadSelectionIndex(index: Int) = Unit
-    override fun clearSelection() = Unit
-    override fun isSelectionEmpty(): Boolean = true
-    override fun insertIndexInterval(index: Int, length: Int, before: Boolean) = Unit
-    override fun removeIndexInterval(index0: Int, index1: Int) = Unit
-}
-
-class ReifiedJXTable<T : TableModel>(
-    model: T,
-    private val modelClass: Class<T>,
-    columns: ColumnList<*>?,
-) : JXTable(model) {
-    private val setup = true
-
-    private val packLater: () -> Unit = debounce(
-        waitTime = 500.milliseconds,
-        coroutineScope = EDT_SCOPE,
-        destinationFunction = ::packAll,
-    )
-
-    init {
-        if (columns != null) {
-            columnFactory = columns.toColumnFactory()
-            createDefaultColumnsFromModel()
-        }
-        isColumnControlVisible = true
-
-        setDefaultRenderer<String>(
-            getText = { it },
-            getTooltip = { it },
-        )
-
-        setSortOrderCycle(ASCENDING, DESCENDING, UNSORTED)
-
-        // TODO header name as tooltip without breaking sorting
-
-        addHighlighter(
-            object : ColorHighlighter(HighlightPredicate.ODD) {
-                override fun getBackground(): Color? = UIManager.getColor("UIColorHighlighter.stripingBackground")
-            },
-        )
-
-        packLater()
-        actionMap.remove("find")
-    }
-
-    override fun createDefaultColumnControl(): JComponent {
-        return ColumnControlButton(this, FlatSVGIcon("icons/bx-column.svg").derive(0.8F))
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    override fun getModel(): T = super.getModel() as T
-
-    override fun setModel(model: TableModel) {
-        if (setup) { // not sure why this is required, something with Kotlin's late initialization
-            require(model::class.java == modelClass) { "Expected $modelClass but got ${model::class.java}" }
-        }
-        val sortedColumn = sortedColumnIndex
-        val sortedColumnIsVisible = convertColumnIndexToView(sortedColumn) != -1
-
-        val sortOrder = if (sortedColumn >= 0) (rowSorter as SortController<*>).getSortOrder(sortedColumn) else null
-
-        val previousColumnSizes = IntArray(columnCount) { i ->
-            getColumnExt(i).preferredWidth
-        }
-
-        super.setModel(model)
-
-        if (sortOrder != null && sortedColumnIsVisible) {
-            setSortOrder(sortedColumn, sortOrder)
-        }
-        if (setup) {
-            for (index in 0 until columnCount) {
-                val previousSize = previousColumnSizes.getOrNull(index)
-                if (previousSize != null) {
-                    getColumnExt(index).preferredWidth = previousSize
-                }
-            }
-            packLater()
-        }
-    }
-
-    companion object {
-        inline operator fun <reified T : TableModel> invoke(
-            model: T,
-            columns: ColumnList<*>? = null,
-        ): ReifiedJXTable<T> {
-            return ReifiedJXTable(model, T::class.java, columns)
-        }
-    }
-}
-
-class FileFilter(
-    private val description: String,
-    private val predicate: (path: Path) -> Boolean,
-) : SwingFileFilter(), FileFilter {
-    constructor(description: String, extensions: List<String>) : this(description, { file -> file.extension in extensions })
-
-    fun accept(path: Path): Boolean {
-        return path.isDirectory() || predicate(path)
-    }
-
-    override fun accept(file: File): Boolean = file.isDirectory() || accept(file.toPath())
-
-    override fun getDescription(): String = description
-}
-
 fun JFileChooser.chooseFiles(parent: JComponent): List<File>? {
     return if (showOpenDialog(parent) == JFileChooser.APPROVE_OPTION) {
         selectedFiles.toList()
@@ -351,142 +70,12 @@ fun JFileChooser.chooseFiles(parent: JComponent): List<File>? {
     }
 }
 
-abstract class AbstractTreeNode : TreeNode {
-    open val children: MutableList<TreeNode> = object : ArrayList<TreeNode>() {
-        override fun add(element: TreeNode): Boolean {
-            element as AbstractTreeNode
-            element.parent = this@AbstractTreeNode
-            return super.add(element)
-        }
-    }
-    var parent: AbstractTreeNode? = null
-
-    override fun getAllowsChildren(): Boolean = true
-    override fun getChildCount(): Int = children.size
-    override fun isLeaf(): Boolean = children.isEmpty()
-    override fun getChildAt(childIndex: Int): TreeNode = children[childIndex]
-    override fun getIndex(node: TreeNode?): Int = children.indexOf(node)
-    override fun getParent(): TreeNode? = this.parent
-    override fun children(): Enumeration<out TreeNode> = Collections.enumeration(children)
-}
-
-abstract class TypedTreeNode<T> : AbstractTreeNode() {
-    abstract val userObject: T
-}
-
 inline fun <reified T : EventListener> EventListenerList.add(listener: T) {
     add(T::class.java, listener)
 }
 
 inline fun <reified T : EventListener> EventListenerList.getAll(): Array<T> {
     return getListeners(T::class.java)
-}
-
-/**
- * Constructs and (optionally) immediately displays a JFrame of the given dimensions, centered on the screen.
- */
-inline fun jFrame(
-    title: String,
-    width: Int,
-    height: Int,
-    initiallyVisible: Boolean = true,
-    embedContentIntoTitleBar: Boolean = false,
-    block: JFrame.() -> Unit,
-) = JFrame(title).apply {
-    setSize(width, height)
-
-    if (embedContentIntoTitleBar && SystemInfo.isMacFullWindowContentSupported) {
-        rootPane.putClientProperty("apple.awt.windowTitleVisible", false)
-        rootPane.putClientProperty("apple.awt.fullWindowContent", true)
-        rootPane.putClientProperty("apple.awt.transparentTitleBar", true)
-    }
-
-    iconImages = frameIcons
-    defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
-
-    setLocationRelativeTo(null)
-
-    block()
-
-    isVisible = initiallyVisible
-}
-
-inline fun <reified T> JComboBox<T>.configureCellRenderer(
-    noinline block: BasicComboBoxRenderer.(list: JList<*>, value: T?, index: Int, isSelected: Boolean, cellHasFocus: Boolean) -> Unit,
-) {
-    renderer = object : BasicComboBoxRenderer() {
-        override fun getListCellRendererComponent(
-            list: JList<*>,
-            value: Any?,
-            index: Int,
-            isSelected: Boolean,
-            cellHasFocus: Boolean,
-        ): Component {
-            super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus)
-            block(list, value as T?, index, isSelected, cellHasFocus)
-            return this
-        }
-    }
-}
-
-inline fun StyledLabel(block: StyledLabelBuilder.() -> Unit): StyledLabel {
-    return StyledLabelBuilder().apply(block).createLabel()
-}
-
-inline fun StyledLabel.style(block: StyledLabelBuilder.() -> Unit) {
-    StyledLabelBuilder().apply {
-        block()
-        clearStyleRanges()
-        configure(this@style)
-    }
-}
-
-fun EmptyBorder(): EmptyBorder = EmptyBorder(0, 0, 0, 0)
-
-val TableModel.rowIndices get() = 0 until rowCount
-val TableModel.columnIndices get() = 0 until columnCount
-
-fun TableModel.exportToCSV(file: File) {
-    file.printWriter().use { out ->
-        columnIndices.joinTo(buffer = out, separator = ",") { col ->
-            getColumnName(col)
-        }
-        out.println()
-        for (row in rowIndices) {
-            columnIndices.joinTo(buffer = out, separator = ",") { col ->
-                "\"${getValueAt(row, col)?.toString().orEmpty()}\""
-            }
-            out.println()
-        }
-    }
-}
-
-fun TableModel.exportToXLSX(file: File) = file.outputStream().use { fos ->
-    workbook {
-        sheet("Sheet 1") { // TODO: Some way to pipe in a more useful sheet name (or multiple sheets?)
-            row {
-                for (col in columnIndices) {
-                    cell(getColumnName(col))
-                }
-            }
-            for (row in rowIndices) {
-                row {
-                    for (col in columnIndices) {
-                        when (val value = getValueAt(row, col)) {
-                            is Double -> cell(
-                                value,
-                                createCellStyle {
-                                    dataFormat = xssfWorkbook.createDataFormat().getFormat("0.00")
-                                },
-                            )
-
-                            else -> cell(value ?: "")
-                        }
-                    }
-                }
-            }
-        }
-    }.xssfWorkbook.write(fos)
 }
 
 fun Component.traverseChildren(): Sequence<Component> = sequence {
@@ -499,8 +88,6 @@ fun Component.traverseChildren(): Sequence<Component> = sequence {
     }
 }
 
-val menuShortcutKeyMaskEx = Toolkit.getDefaultToolkit().menuShortcutKeyMaskEx
-
 fun SVGDocument.render(width: Int, height: Int, x: Int = 0, y: Int = 0): BufferedImage {
     return BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB).apply {
         val g = createGraphics()
@@ -508,32 +95,6 @@ fun SVGDocument.render(width: Int, height: Int, x: Int = 0, y: Int = 0): Buffere
         render(null, g, ViewBox(x.toFloat(), y.toFloat(), width.toFloat(), height.toFloat()))
         g.dispose()
     }
-}
-
-@Suppress("FunctionName")
-fun HorizontalSplitPane(
-    left: Component,
-    right: Component,
-    resizeWeight: Double = 0.5,
-    block: JSplitPane.() -> Unit = {},
-) = JSplitPane(SwingConstants.VERTICAL, left, right).apply {
-    isOneTouchExpandable = true
-    this.resizeWeight = resizeWeight
-
-    block()
-}
-
-@Suppress("FunctionName")
-fun VerticalSplitPane(
-    top: Component,
-    bottom: Component,
-    resizeWeight: Double = 0.5,
-    block: JSplitPane.() -> Unit = {},
-) = JSplitPane(SwingConstants.HORIZONTAL, top, bottom).apply {
-    isOneTouchExpandable = true
-    this.resizeWeight = resizeWeight
-
-    block()
 }
 
 inline fun <reified C> Component.getAncestorOfClass(): C? {

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/Tables.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/Tables.kt
@@ -1,0 +1,67 @@
+package io.github.inductiveautomation.kindling.utils
+
+import io.github.evanrupert.excelkt.workbook
+import java.io.File
+import javax.swing.JTable
+import javax.swing.table.TableModel
+
+fun JTable.selectedRowIndices(): IntArray {
+    return selectionModel.selectedIndices
+        .filter { isRowSelected(it) }
+        .map { convertRowIndexToModel(it) }
+        .toIntArray()
+}
+
+fun JTable.selectedOrAllRowIndices(): IntArray {
+    return if (selectionModel.isSelectionEmpty) {
+        IntArray(model.rowCount) { it }
+    } else {
+        selectedRowIndices()
+    }
+}
+
+val TableModel.rowIndices get() = 0 until rowCount
+val TableModel.columnIndices get() = 0 until columnCount
+
+fun TableModel.exportToCSV(file: File) {
+    file.printWriter().use { out ->
+        columnIndices.joinTo(buffer = out, separator = ",") { col ->
+            getColumnName(col)
+        }
+        out.println()
+        for (row in rowIndices) {
+            columnIndices.joinTo(buffer = out, separator = ",") { col ->
+                "\"${getValueAt(row, col)?.toString().orEmpty()}\""
+            }
+            out.println()
+        }
+    }
+}
+
+fun TableModel.exportToXLSX(file: File) = file.outputStream().use { fos ->
+    workbook {
+        sheet("Sheet 1") { // TODO: Some way to pipe in a more useful sheet name (or multiple sheets?)
+            row {
+                for (col in columnIndices) {
+                    cell(getColumnName(col))
+                }
+            }
+            for (row in rowIndices) {
+                row {
+                    for (col in columnIndices) {
+                        when (val value = getValueAt(row, col)) {
+                            is Double -> cell(
+                                value,
+                                createCellStyle {
+                                    dataFormat = xssfWorkbook.createDataFormat().getFormat("0.00")
+                                },
+                            )
+
+                            else -> cell(value ?: "")
+                        }
+                    }
+                }
+            }
+        }
+    }.xssfWorkbook.write(fos)
+}

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/Trees.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/Trees.kt
@@ -1,0 +1,28 @@
+package io.github.inductiveautomation.kindling.utils
+
+import java.util.Collections
+import java.util.Enumeration
+import javax.swing.tree.TreeNode
+
+abstract class AbstractTreeNode : TreeNode {
+    open val children: MutableList<TreeNode> = object : ArrayList<TreeNode>() {
+        override fun add(element: TreeNode): Boolean {
+            element as AbstractTreeNode
+            element.parent = this@AbstractTreeNode
+            return super.add(element)
+        }
+    }
+    var parent: AbstractTreeNode? = null
+
+    override fun getAllowsChildren(): Boolean = true
+    override fun getChildCount(): Int = children.size
+    override fun isLeaf(): Boolean = children.isEmpty()
+    override fun getChildAt(childIndex: Int): TreeNode = children[childIndex]
+    override fun getIndex(node: TreeNode?): Int = children.indexOf(node)
+    override fun getParent(): TreeNode? = this.parent
+    override fun children(): Enumeration<out TreeNode> = Collections.enumeration(children)
+}
+
+abstract class TypedTreeNode<T> : AbstractTreeNode() {
+    abstract val userObject: T
+}

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/zip/ZipView.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/zip/ZipView.kt
@@ -191,7 +191,7 @@ object ZipViewer : Tool {
     override val title = "Ignition Archive"
     override val description = "Archives (.gwbk, .zip, .modl)"
     override val icon = FlatSVGIcon("icons/bx-archive.svg")
-    override val filter = FileFilter(description, listOf("gwbk", "zip", "modl", "jar"))
+    override val filter = FileFilter(description, "gwbk", "zip", "modl", "jar")
 
     override fun open(path: Path): ToolPanel = ZipView(path)
 


### PR DESCRIPTION
- Removes the attempt at rendering a "minimap" of log events in the scrollbar. I briefly pursued rendering a "real" chart there, via JFreeChart, but never got it working particularly well _and_ keeping it in sync with scrolling, table sorting, etc turned out to be a real headache. Might still revisit this someday, but I think this PR sufficiently covers the ultimate goal.
- Adds a 'Dense Times' table to the log view. This renders a table displaying _minutes_ which had more than 60 logged messages, an arbitrary threshold that seemed to work okay on the logs I tested against. You can double click or right click on the rows of this table to jump to the relevant event in the main log view. 
- Adds a new 'Capture Range' button to the log view. This takes the min and max timestamp currently visible, applies it to the time filter, and then removes all other filters, allowing you to isolate a few event(s), then see their surrounding context more easily.
  - And to make that "context exploration" easier (and cover #71), I added buttons below each date time selector to add or remove fixed minute increments. These buttons will properly roll over hours and even days, allowing you to quickly expand or contract the time range precisely.

I also changed FilterSidebar to check if the individual components are instances of PopupMenuCustomizer, allowing them to add their own decoration to the popup menu that previously only showed 'Reset'. This is now used on the Logger tab to quickly allow you to set the global 'Show Full Logger Names' preference.

Finally, I did some reorganization to break up the `Swing.kt` class into more clearly delineated files. 

Fixes #71 
Fixes #17 (not really, but I'm closing that issue down anyways)