### PR TITLE
(Temporary) fix for tool loading order in archives

### DIFF
--- a/src/main/kotlin/io/github/inductiveautomation/kindling/MainPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/MainPanel.kt
@@ -102,7 +102,9 @@ class MainPanel : JPanel(MigLayout("ins 6, fill, hidemode 3")) {
             )
         }
 
-        Tool.byFilter.keys.forEach(this::addChoosableFileFilter)
+        Tool.sortedByTitle.forEach { tool ->
+            addChoosableFileFilter(tool.filter)
+        }
         fileFilter = DefaultTool.currentValue.filter
         addPropertyChangeListener(JFileChooser.FILE_FILTER_CHANGED_PROPERTY) { e ->
             val relevantTool = Tool.byFilter[e.newValue as FileFilter]
@@ -137,7 +139,7 @@ class MainPanel : JPanel(MigLayout("ins 6, fill, hidemode 3")) {
                 font = font.deriveFont(24F)
             },
         )
-        for (tools in Tool.tools.sortedBy { it.title }.chunked(3)) {
+        for (tools in Tool.sortedByTitle.chunked(3)) {
             add(toolTile(tools[0]), "sg tile, h 200!, newline, split, gaptop 20")
             for (tool in tools.drop(1)) {
                 add(toolTile(tool), "sg tile, gap 20 0 20 0")
@@ -222,7 +224,7 @@ class MainPanel : JPanel(MigLayout("ins 6, fill, hidemode 3")) {
 
     private val fileMenu = JMenu("File").apply {
         add(openAction)
-        for (tool in Tool.tools) {
+        for (tool in Tool.sortedByTitle) {
             add(
                 Action(
                     name = "Open ${tool.title}",

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/core/Kindling.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/core/Kindling.kt
@@ -78,7 +78,7 @@ data object Kindling {
                 default = Tool.tools.first(),
                 serializer = ToolSerializer,
                 editor = {
-                    JComboBox(Vector(Tool.tools)).apply {
+                    JComboBox(Vector(Tool.sortedByTitle)).apply {
                         selectedItem = currentValue
 
                         configureCellRenderer { _, value, _, selected, focused ->

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/core/Tool.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/core/Tool.kt
@@ -55,7 +55,11 @@ interface Tool : KindlingSerializable {
                 add(AlarmViewer)
                 add(XmlTool)
                 addAll(loadService<Tool>())
-            }.sortedBy { it.title }
+            }
+        }
+
+        val sortedByTitle: List<Tool> by lazy {
+            tools.sortedBy { it.title }
         }
 
         val byFilter: Map<FileFilter, Tool> by lazy {


### PR DESCRIPTION
1. Removes the default sort of `Tool.tools`, so that the manual lookup methods still follow the explicit ordering present in the list
2. Adds a new 'sortedByTitle' variant that's used for all user-facing display points to minimize confusion