### PR TITLE
Add Java serialized data viewer "advanced" tool

### DIFF
--- a/src/main/kotlin/io/github/inductiveautomation/kindling/MainPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/MainPanel.kt
@@ -139,7 +139,7 @@ class MainPanel : JPanel(MigLayout("ins 6, fill, hidemode 3")) {
                 putClientProperty("FlatLaf.styleClass", "h1")
             },
         )
-        for (tools in Tool.sortedByTitle.chunked(3)) {
+        for (tools in Tool.sortedByTitle.filterNot { it.isAdvanced }.chunked(3)) {
             add(toolTile(tools[0]), "sg tile, h 200!, newline, split, gaptop 20")
             for (tool in tools.drop(1)) {
                 add(toolTile(tool), "sg tile, gap 20 0 20 0")

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/core/Tool.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/core/Tool.kt
@@ -6,6 +6,7 @@ import io.github.inductiveautomation.kindling.cache.CacheViewer
 import io.github.inductiveautomation.kindling.gatewaynetwork.GatewayNetworkTool
 import io.github.inductiveautomation.kindling.idb.IdbViewer
 import io.github.inductiveautomation.kindling.log.LogViewer
+import io.github.inductiveautomation.kindling.serial.SerialViewer
 import io.github.inductiveautomation.kindling.thread.MultiThreadViewer
 import io.github.inductiveautomation.kindling.utils.FileFilter
 import io.github.inductiveautomation.kindling.utils.loadService
@@ -39,6 +40,12 @@ interface Tool : KindlingSerializable {
     val requiresHiddenFiles: Boolean
         get() = false
 
+    /**
+     * True if this tool is primarily intended for "advanced" users, and as such should be de-emphasized in the main UI.
+     */
+    val isAdvanced: Boolean
+        get() = false
+
     fun open(path: Path): ToolPanel
 
     val filter: FileFilter
@@ -54,6 +61,7 @@ interface Tool : KindlingSerializable {
                 add(GatewayNetworkTool)
                 add(AlarmViewer)
                 add(XmlTool)
+                add(SerialViewer)
                 addAll(loadService<Tool>())
             }
         }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/serial/SerialViewer.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/serial/SerialViewer.kt
@@ -34,16 +34,21 @@ class SerialViewPanel(private val path: Path) : ToolPanel() {
         rawBytes.text = path.inputStream().toHumanReadableBinary()
         name = path.name
 
-        add(JLabel("Java Serialized Data: ${data.size} bytes").apply {
-            putClientProperty("FlatLaf.styleClass", "h3.regular")
-        }, "wrap")
-        add(HorizontalSplitPane(
-            FlatScrollPane(serialDump),
-            FlatScrollPane(rawBytes),
-            resizeWeight = 0.8,
-        ) {
-
-        }, "push, grow")
+        add(
+            JLabel("Java Serialized Data: ${data.size} bytes").apply {
+                putClientProperty("FlatLaf.styleClass", "h3.regular")
+            },
+            "wrap",
+        )
+        add(
+            HorizontalSplitPane(
+                FlatScrollPane(serialDump),
+                FlatScrollPane(rawBytes),
+                resizeWeight = 0.8,
+            ) {
+            },
+            "push, grow",
+        )
     }
 
     override val icon: Icon = SerialViewer.icon

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/serial/SerialViewer.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/serial/SerialViewer.kt
@@ -1,0 +1,67 @@
+package io.github.inductiveautomation.kindling.serial
+
+import com.formdev.flatlaf.extras.FlatSVGIcon
+import deser.SerializationDumper
+import io.github.inductiveautomation.kindling.core.Tool
+import io.github.inductiveautomation.kindling.core.ToolPanel
+import io.github.inductiveautomation.kindling.utils.FileFilter
+import io.github.inductiveautomation.kindling.utils.FlatScrollPane
+import io.github.inductiveautomation.kindling.utils.HorizontalSplitPane
+import io.github.inductiveautomation.kindling.utils.toHumanReadableBinary
+import java.awt.Font
+import java.nio.file.Path
+import javax.swing.Icon
+import javax.swing.JLabel
+import javax.swing.JTextArea
+import kotlin.io.path.inputStream
+import kotlin.io.path.name
+import kotlin.io.path.readBytes
+
+class SerialViewPanel(private val path: Path) : ToolPanel() {
+    private val serialDump = JTextArea().apply {
+        font = Font(Font.MONOSPACED, Font.PLAIN, 12)
+        isEditable = false
+    }
+
+    private val rawBytes = JTextArea().apply {
+        font = Font(Font.MONOSPACED, Font.PLAIN, 12)
+        isEditable = false
+    }
+
+    init {
+        val data = path.readBytes()
+        serialDump.text = SerializationDumper(data).parseStream()
+        rawBytes.text = path.inputStream().toHumanReadableBinary()
+        name = path.name
+
+        add(JLabel("Java Serialized Data: ${data.size} bytes").apply {
+            putClientProperty("FlatLaf.styleClass", "h3.regular")
+        }, "wrap")
+        add(HorizontalSplitPane(
+            FlatScrollPane(serialDump),
+            FlatScrollPane(rawBytes),
+            resizeWeight = 0.8,
+        ) {
+
+        }, "push, grow")
+    }
+
+    override val icon: Icon = SerialViewer.icon
+
+    override fun getToolTipText(): String? {
+        return path.toString()
+    }
+}
+
+data object SerialViewer : Tool {
+    override val title: String = "Java Serialization Viewer"
+    override val description: String = "Serial files"
+    override val icon: FlatSVGIcon = FlatSVGIcon("icons/bx-code.svg")
+
+    override fun open(path: Path): ToolPanel = SerialViewPanel(path)
+
+    override val filter: FileFilter = FileFilter("Java Serialized File", "bin")
+    override val serialKey: String = "serial-viewer"
+
+    override val isAdvanced: Boolean = true
+}

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/General.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/General.kt
@@ -149,6 +149,7 @@ fun InputStream.toHumanReadableBinary(): String {
 
                 // the last read might not be complete, so there could be stale data in the buffer
                 val toRead = buffer.sliceArray(0 until numberOfBytesRead)
+
                 @OptIn(ExperimentalStdlibApi::class)
                 val hexBytes = toRead.toHexString(HEX_FORMAT)
                 val decodedBytes = decodeBytes(toRead)

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/zip/views/FileView.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/zip/views/FileView.kt
@@ -5,6 +5,7 @@ import io.github.inductiveautomation.kindling.core.Kindling.Preferences.UI.Theme
 import io.github.inductiveautomation.kindling.core.Theme.Companion.theme
 import io.github.inductiveautomation.kindling.utils.asActionIcon
 import io.github.inductiveautomation.kindling.utils.configureCellRenderer
+import io.github.inductiveautomation.kindling.utils.toHumanReadableBinary
 import io.github.inductiveautomation.kindling.zip.views.FileView.SyntaxStyle.CSS
 import io.github.inductiveautomation.kindling.zip.views.FileView.SyntaxStyle.JSON
 import io.github.inductiveautomation.kindling.zip.views.FileView.SyntaxStyle.Plaintext
@@ -135,7 +136,7 @@ class FileView(override val provider: FileSystemProvider, override val path: Pat
         val text = if (charset != null) {
             readFileAsString(charset)
         } else {
-            readFileAsBytes()
+            provider.newInputStream(path).toHumanReadableBinary()
         }
 
         textArea.text = if (syntaxCombo.selectedItem as SyntaxStyle == JSON) {
@@ -157,51 +158,11 @@ class FileView(override val provider: FileSystemProvider, override val path: Pat
         }
     }
 
-    @OptIn(ExperimentalStdlibApi::class)
-    private fun readFileAsBytes(): String {
-        provider.newInputStream(path).use { file ->
-            val windowSize = 16
-            return sequence {
-                val buffer = ByteArray(windowSize)
-                var numberOfBytesRead: Int
-                do {
-                    numberOfBytesRead = file.readNBytes(buffer, 0, windowSize)
-
-                    // the last read might not be complete, so there could be stale data in the buffer
-                    val toRead = buffer.sliceArray(0 until numberOfBytesRead)
-                    val hexBytes = toRead.toHexString(HEX_FORMAT)
-                    val decodedBytes = decodeBytes(toRead)
-                    yield("${hexBytes.padEnd(47)}  $decodedBytes")
-                } while (numberOfBytesRead == windowSize)
-            }.joinToString(separator = "\n")
-        }
-    }
-
-    private fun decodeBytes(toRead: ByteArray): String {
-        return String(
-            CharArray(toRead.size) { i ->
-                val byte = toRead[i]
-                if (byte >= 0 && !Character.isISOControl(byte.toInt())) {
-                    Char(byte.toUShort())
-                } else {
-                    '.'
-                }
-            },
-        )
-    }
-
     companion object {
         @OptIn(ExperimentalSerializationApi::class)
         private val JSON_FORMAT = Json {
             prettyPrint = true
             prettyPrintIndent = "  "
-        }
-
-        @OptIn(ExperimentalStdlibApi::class)
-        private val HEX_FORMAT = HexFormat {
-            bytes {
-                byteSeparator = " "
-            }
         }
 
         private val KNOWN_EXTENSIONS: Map<String, SyntaxStyle> = mapOf(


### PR DESCRIPTION
Simple utility I started using for 8.3 development. Not much practical use to most end users, so I added the "advanced" toggle to the tool settings, so we aren't featuring this as prominently in the UI. Might still be too much - might want to gate this behind a setting or something, but this seems fine for now.