### PR TITLE
Added rename tabs functionality

### DIFF
--- a/src/main/kotlin/io/github/inductiveautomation/kindling/MainPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/MainPanel.kt
@@ -172,7 +172,7 @@ class MainPanel : JPanel(MigLayout("ins 6, fill, hidemode 3")) {
         border = EmptyBorder()
     }
 
-    private val tabs = object : TabStrip() {
+    private val tabs = object : TabStrip(tabsEditable = true) {
         init {
             name = "MainTabStrip"
             isVisible = false

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/TabStrip.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/TabStrip.kt
@@ -8,6 +8,10 @@ import java.awt.Container
 import java.awt.event.ComponentAdapter
 import java.awt.event.ComponentEvent
 import java.awt.event.ComponentListener
+import java.awt.event.KeyAdapter
+import java.awt.event.KeyEvent
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
 import javax.swing.Icon
 import javax.swing.JComponent
 import javax.swing.JFrame
@@ -15,6 +19,7 @@ import javax.swing.JMenu
 import javax.swing.JMenuBar
 import javax.swing.JPanel
 import javax.swing.JPopupMenu
+import javax.swing.JTextField
 
 interface PopupMenuCustomizer {
     fun customizePopupMenu(menu: JPopupMenu)
@@ -27,7 +32,7 @@ interface FloatableComponent {
 }
 
 @Suppress("LeakingThis")
-open class TabStrip : DnDTabbedPane() {
+open class TabStrip(val tabsEditable: Boolean = false) : DnDTabbedPane() {
     init {
         tabPlacement = TOP
         tabLayoutPolicy = SCROLL_TAB_LAYOUT
@@ -37,7 +42,21 @@ open class TabStrip : DnDTabbedPane() {
         setTabCloseCallback { _, i ->
             removeTabAt(i)
         }
-
+        if (tabsEditable) {
+            addMouseListener(
+                object : MouseAdapter() {
+                    override fun mouseClicked(e: MouseEvent?) {
+                        if (e != null && e.clickCount == 2) {
+                            val tabIndex = indexAtLocation(e.x, e.y)
+                            if (tabIndex == -1) return
+                            if (isTabClosable(tabIndex)) {
+                                editTabTitle(tabIndex)
+                            }
+                        }
+                    }
+                },
+            )
+        }
         attachPopupMenu { event ->
             val tabIndex = indexAtLocation(event.x, event.y)
             if (tabIndex == -1) return@attachPopupMenu null
@@ -74,6 +93,13 @@ open class TabStrip : DnDTabbedPane() {
                             }
                         },
                     )
+                    if (tabsEditable && isTabClosable(tabIndex)) {
+                        add(
+                            Action("Rename Tab") {
+                                editTabTitle(tabIndex)
+                            },
+                        )
+                    }
                     val closable = isTabClosable(tabIndex)
                     add(
                         Action(if (closable) "Pin" else "Unpin") {
@@ -149,6 +175,32 @@ open class TabStrip : DnDTabbedPane() {
                 },
             ),
         )
+    }
+
+    fun editTabTitle(tabIndex: Int) {
+        val textField = JTextField(
+            getTitleAt(tabIndex),
+        )
+
+        textField.addKeyListener(
+            object : KeyAdapter() {
+                override fun keyPressed(e: KeyEvent?) {
+                    if (e?.keyCode == KeyEvent.VK_ENTER) {
+                        val newTabName: String? = textField.text
+                        if (!newTabName.isNullOrBlank()) {
+                            setTitleAt(tabIndex, newTabName)
+                            setTabComponentAt(tabIndex, null)
+                        }
+                    }
+                    if (e?.keyCode == KeyEvent.VK_ESCAPE) {
+                        setTabComponentAt(tabIndex, null)
+                    }
+                }
+            },
+        )
+
+        setTabComponentAt(tabIndex, textField)
+        textField.requestFocusInWindow()
     }
 
     open class LazyTab(


### PR DESCRIPTION
Functionality involves:

- Double clicking to rename tab.
- Right Clicking to view Rename option and rename tab
- Tabs which are pinned cannot be renamed
- Press Enter to confirm changes and Escape to cancel
![image](https://github.com/user-attachments/assets/9687dc67-7857-4947-8757-8a19f5ff2404)
![image](https://github.com/user-attachments/assets/8d56bf7b-a77a-413f-bf9d-ef35830633af)
