### PR TITLE
Fix logger names not sorting correctly

### DIFF
--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/LoggerNamePanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/LoggerNamePanel.kt
@@ -147,7 +147,7 @@ class LoggerNamePanel<T : LogEvent>(private val rawData: List<T>) :
 
             newExpandedPaths.forEach(filterTree::expandPath)
         }
-        filterList.model = FilterModel.fromRawData(data, filterList.comparator) { it.logger }
+        filterList.model = FilterModel.fromRawData(data, filterList.comparator, sortKey = ::getSortKey) { it.logger }
     }
 
     override fun filter(item: T): Boolean = if (isTreeMode) {


### PR DESCRIPTION
Logger names were not sorting correctly alphabetically.

Small fix to correct the sort key used so that logger names sort based on either full or partial name depending on preference.