### PR TITLE
prevent idb connection from closing to allow for SQL queries using the IDB SQLite Database tool

### DIFF
--- a/src/main/kotlin/io/github/inductiveautomation/kindling/idb/IdbView.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/idb/IdbView.kt
@@ -157,7 +157,7 @@ private enum class MultiIdbTool : IdbTool {
 
             val logFiles = fileData.map { (_, connection, _) ->
                 LogFile(
-                    connection.parseLogs().also { connection.close() },
+                    connection.parseLogs(),
                 )
             }
 


### PR DESCRIPTION
This PR suggests a fix for https://github.com/inductiveautomation/kindling/issues/273


Previously, when you attempted to use the sql query tool on a system_logs.idb file. It would error out because the idb file connection is closed after being loaded in.

This small patch just prevents this from being closed so we can use the sql query tool.

This shouldn't have any unintended affects as idb files (for now) are read only so we don't really need to worry about corruption

Fixes #273 