### PR TITLE
filter unmarked only in logs

### DIFF
--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/LogPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/LogPanel.kt
@@ -471,7 +471,4 @@ enum class MarkedBehavior(val displayName: String) {
     OnlyMarked("Only Show Marked"),
     OnlyUnmarked("Only Show Unmarked"),
     AlwaysShowMarked("Always Show Marked"),
-    ;
-
-    override fun toString(): String = displayName
 }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/LogPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/LogPanel.kt
@@ -101,8 +101,11 @@ sealed class LogPanel<T : LogEvent>(
     protected val filters = mutableListOf<Filter<T>>(
         object : Filter<T> {
             override fun filter(item: T): Boolean {
-                return header.markedBehavior.selectedItem != "Only Show Marked" ||
-                    item.marked
+                return when (header.markedBehavior.selectedItem) {
+                    "Only Show Marked" -> item.marked
+                    "Only Show Unmarked" -> !item.marked
+                    else -> true // "Show All Events" and fallback
+                }
             }
         },
     )
@@ -405,7 +408,7 @@ sealed class LogPanel<T : LogEvent>(
         val nextMarked = JButton(FlatActionIcon("icons/bx-arrow-down.svg")).apply {
             toolTipText = "Jump to next marked log event"
         }
-        val markedBehavior = JComboBox(arrayOf("Show All Events", "Only Show Marked", "Always Show Marked"))
+        val markedBehavior = JComboBox(arrayOf("Show All Events", "Only Show Marked", "Only Show Unmarked", "Always Show Marked"))
 
         private val markedPanel = JPanel(MigLayout("fill, ins 0 2 0 2")).apply {
             border = BorderFactory.createTitledBorder("Marking")

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/LogPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/LogPanel.kt
@@ -484,7 +484,8 @@ enum class MarkedBehavior(val displayName: String) {
     },
     AlwaysShowMarked("Always Show Marked") {
         override fun shouldInclude(event: LogEvent) = true // filtering handled separately
-    };
+    }, ;
+
     abstract fun shouldInclude(event: LogEvent): Boolean
     override fun toString(): String = displayName
     companion object {

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/thread/MultiThreadView.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/thread/MultiThreadView.kt
@@ -43,7 +43,6 @@ import net.miginfocom.swing.MigLayout
 import org.jdesktop.swingx.JXSearchField
 import org.jdesktop.swingx.table.ColumnControlButton.COLUMN_CONTROL_MARKER
 import java.awt.Desktop
-import java.awt.Rectangle
 import java.nio.file.Path
 import javax.swing.ButtonGroup
 import javax.swing.JLabel
@@ -293,7 +292,7 @@ class MultiThreadView(
             if (newSelectedIndex > -1) {
                 val newSelectedViewIndex = mainTable.convertRowIndexToView(newSelectedIndex)
                 mainTable.selectionModel.setSelectionInterval(0, newSelectedViewIndex)
-                mainTable.scrollRectToVisible(Rectangle(mainTable.getCellRect(newSelectedViewIndex, 0, true)))
+                mainTable.scrollRectToVisible(mainTable.getCellRect(newSelectedViewIndex, 0, true))
             }
         }
 
@@ -362,7 +361,7 @@ class MultiThreadView(
                 if (selectedID == mainTable.model[i, mainTable.model.columns.id]) {
                     val rowIndex = mainTable.convertRowIndexToView(i)
                     mainTable.selectionModel.setSelectionInterval(0, rowIndex)
-                    mainTable.scrollRectToVisible(Rectangle(mainTable.getCellRect(rowIndex, 0, true)))
+                    mainTable.scrollRectToVisible(mainTable.getCellRect(rowIndex, 0, true))
                     break
                 }
             }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/Swing.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/Swing.kt
@@ -34,6 +34,7 @@ import javax.swing.JPopupMenu
 import javax.swing.JScrollPane
 import javax.swing.JTextField
 import javax.swing.KeyStroke
+import javax.swing.ListSelectionModel
 import javax.swing.SwingUtilities
 import javax.swing.event.DocumentEvent
 import javax.swing.event.DocumentListener
@@ -217,3 +218,9 @@ fun Color.toHexString(alpha: Boolean = false): String {
         }
     }"
 }
+
+val ListSelectionModel.minSelectedIndex: Int?
+    get() = minSelectionIndex.takeIf { it != -1 }
+
+val ListSelectionModel.maxSelectedIndex: Int?
+    get() = maxSelectionIndex.takeIf { it != -1 }


### PR DESCRIPTION
This PR suggests a fix for: https://github.com/inductiveautomation/kindling/issues/260

It is a simple addition that just adds a filter for unmarked only items. 

![image](https://github.com/user-attachments/assets/b940f46f-afc4-467c-865e-31b0e2b33f35)

This is actually a really nice feature for when you have a lot of logs you want to export but there's a few you want to cherry-pick to remove.

With the current implementation, if you have have 3 tasks unmarked for example and you mark one it doesn't remove it from the list until you re-apply this filter. I actually think this is better though and it prevents mis-clicking one and needing to try and find it because it was removed right away. (This is also how the current "Only Show Marked" works as well!)

Fixes #260 