### PR TITLE
Fix comparison pane not able to be shrunk

### DIFF
--- a/src/main/kotlin/io/github/inductiveautomation/kindling/thread/MultiThreadView.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/thread/MultiThreadView.kt
@@ -383,6 +383,8 @@ class MultiThreadView(
             "push, grow, span, wmax 100%",
         )
 
+        comparison.threads = mainTable.model.threadData.first()
+
         sidebar.selectedIndex = 0
     }
 

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/thread/comparison/ThreadComparisonPane.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/thread/comparison/ThreadComparisonPane.kt
@@ -36,7 +36,7 @@ class ThreadComparisonPane(
     }
 
     private val header = HeaderPanel()
-    private val body = JPanel((MigLayout("fill, ins 0, hidemode 3")))
+    private val body = JPanel((MigLayout("fill, ins 3, gap 3, hidemode 3")))
     private val footer = if (totalThreadDumps > 3) FooterPanel() else null
 
     private val threadContainers: List<ThreadContainer> = List(totalThreadDumps) { i ->
@@ -104,12 +104,12 @@ class ThreadComparisonPane(
         add(
             body.apply {
                 for ((index, container) in threadContainers.withIndex()) {
-                    add(container, "grow, sizegroup, w 33%!")
+                    add(container, "grow, sg")
 
                     if (index > 2) container.isVisible = false
                 }
             },
-            "pushy, grow,  spanx, w 100%!",
+            "pushy, grow,  spanx",
         )
 
         if (footer != null) {
@@ -151,18 +151,7 @@ class ThreadComparisonPane(
             container.thread = thread
         }
 
-        footer?.reset() ?: recalculateConstraints()
-    }
-
-    /* Need to calculate the width of the containers after threads have changed. */
-    private fun recalculateConstraints() {
-        val containerSize = 100 / threadContainers.count { it.isViewable && it.isSelected }
-        for (container in threadContainers) {
-            (body.layout as MigLayout).setComponentConstraints(
-                container,
-                "grow, sizegroup, w $containerSize%!",
-            )
-        }
+        footer?.reset()
     }
 
     fun addBlockerSelectedListener(listener: BlockerSelectedEventListener) {
@@ -257,8 +246,6 @@ class ThreadComparisonPane(
                 threadContainers.forEachIndexed { index, threadContainer ->
                     threadContainer.isSelected = index in value
                 }
-
-                recalculateConstraints()
             }
 
         private val canSelectNext: Boolean

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/thread/comparison/ThreadContainer.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/thread/comparison/ThreadContainer.kt
@@ -78,13 +78,13 @@ internal class ThreadContainer(
                 add(diffCheckBox)
                 add(blockerButton, "gapleft 8")
             },
-            "wmax 100%, top, growx",
+            "top, growx",
         )
 
         // Ensure that the top two don't get pushed below their preferred size.
-        add(monitors, "grow, h pref:pref:300, top, wmax 100%")
-        add(synchronizers, "grow, h pref:pref:300, top, wmax 100%")
-        add(stacktrace, "push, grow, top, wmax 100%")
+        add(monitors, "grow, h pref:pref:300, top")
+        add(synchronizers, "grow, h pref:pref:300, top")
+        add(stacktrace, "push, grow, top")
     }
 
     fun updateThreadInfo() {


### PR DESCRIPTION
The thread comparison pane has been plagued by the issue of not being able to be horizontally shrunk since it was first made. The initial implementation of the comparison pane used instances of `JXTaskPane` and `JXTaskPaneContainer` for its presentation, but this was reworked to just use buttons, panels, and text areas due to issues related to the layout of the previously used SwingX components.

After the rework, the problem persisted. This issue bled into other tools as well. If a tab containing a thread dump was open, nothing at all could be shrunk horizontally on the screen, regardless of which tab the user was on.

### Cause
The cause has turned out the be the header buttons for the `DetailContainer` class. In these buttons, I created an override of `getIconTextGap` which tried to utilize the button's size to determine the spacing between the icon and the text in the button, with the end goal being to right-align the icon. This worked, but prevented the button from shrinking.

It seems that the `getIconTextGap` function override, which was using the buttons size, minus a few variables, to determine its location in pixels, was always never receiving the button's updated, smaller size after the user resized the window. My theory is that the button ui uses the `iconTextGap` to determine its overall size, which caused a circular reference preventing the size from updating.


### Solution
The solution I found was to do away with using the button's inherent properties entirely, slap a miglayout on it, and add two labels for the text and icon and space them with Mig. The buttons seem to work fine now and they now properly resize. The only limiting factor establishing a minimum size in the thread viewer is the header, which is fine, as the components in the header will squeeze together until they can't anymore, and then clipping off the window occurs.

I was also able to remove some extra constrainst which were previous needed to fight with the buttons and keep everything sized appropriately. Overall, the comparison pane is a bit cleaner now.

### Afterthought
Is there a way to make it so that the minimum size of a different, closed tab doesn't affect the minimum size of the tab currently open? Not a big deal but I'd be curious to see if that were possible.

### Testing
Open a couple thread dumps and resize the window horizontally (left-right). You will see that everything now shrinks. 

If you perform this test on a build without this commit, the window will only grow, and never shrink back down.