### PR TITLE
Implement 8.3 S&F Cache VIewer

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,10 +23,7 @@ dependencies {
     api(libs.jsvg)
     api(libs.bundles.coroutines)
     api(libs.bundles.flatlaf)
-    api(libs.bundles.ignition) {
-        // Exclude transitive IA dependencies - we only need core Ignition classes for cache deserialization
-        isTransitive = false
-    }
+    api(libs.bundles.ignition) // Gradle will not include these packages unless they are transitive
     api(libs.poi)
     api(libs.excelkt) {
         // bringing in POI manually, since this wrapper appears unmaintained

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "2.2.10"
 coroutines = "1.10.2"
 flatlaf = "3.6.1"
 kotest = "5.9.1"
-ignition = "8.3.0-rc1"
+ignition = "8.3.0"
 jackson = "2.19.2"
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlin = "2.2.10"
 coroutines = "1.10.2"
 flatlaf = "3.6.1"
 kotest = "5.9.1"
-ignition = "8.1.20"
+ignition = "8.3.0-rc1"
 jackson = "2.19.2"
 
 [plugins]
@@ -46,8 +46,8 @@ rsyntaxtextarea = { group = "com.fifesoft", name = "rsyntaxtextarea", version = 
 jfreechart = { group = "org.jfree", name = "jfreechart", version = "1.5.6" }
 
 # Ignition
-ignition-common = { group = "com.inductiveautomation.ignition", name = "common", version.ref = "ignition" }
-ignition-gateway = { group = "com.inductiveautomation.ignition", name = "gateway-api", version.ref = "ignition" }
+ignition-common = { group = "com.inductiveautomation.ignitionsdk", name = "ignition-common", version.ref = "ignition" }
+ignition-gateway = { group = "com.inductiveautomation.ignitionsdk", name = "gateway-api", version.ref = "ignition" }
 # Ignition core types use classes from these libs (e.g. StringUtils, ImmutableMap), so we're forced to include these
 apache-commons = { group = "org.apache.commons", name = "commons-lang3", version = "3.8.1" }
 # This leads to a warning at runtime about multiple logging providers on the classpath, but is unavoidable

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/cache/CacheViewer.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/cache/CacheViewer.kt
@@ -1,0 +1,38 @@
+package io.github.inductiveautomation.kindling.cache
+
+import com.formdev.flatlaf.extras.FlatSVGIcon
+import io.github.inductiveautomation.kindling.core.Tool
+import io.github.inductiveautomation.kindling.core.ToolOpeningException
+import io.github.inductiveautomation.kindling.core.ToolPanel
+import io.github.inductiveautomation.kindling.utils.FileFilter
+import java.nio.file.Path
+import kotlin.io.path.extension
+
+data object CacheViewer : Tool {
+    override val serialKey = "sf-cache"
+    override val title = "Store & Forward Cache"
+    override val description = "S&F Cache (.zip, 8.1: .data, .script, 8.3: .idb)"
+    override val icon = FlatSVGIcon("icons/bx-data.svg")
+    internal val extensions = arrayOf("data", "script", "zip", "idb")
+    override val filter = FileFilter(description, *extensions)
+
+    override fun open(path: Path): ToolPanel {
+        return when (path.extension) {
+            "data",
+            "script" -> {
+                io.github.inductiveautomation.kindling.cache.hsql.CacheView(path)
+            }
+            "idb" -> {
+                io.github.inductiveautomation.kindling.cache.sqlite.CacheView.fromIdb(path)
+            }
+            "zip" -> {
+                try {
+                    io.github.inductiveautomation.kindling.cache.hsql.CacheView(path)
+                } catch(_: Exception) {
+                    io.github.inductiveautomation.kindling.cache.sqlite.CacheView.fromZip(path)
+                }
+            }
+            else -> throw ToolOpeningException("Invalid file extension; ${path.extension}")
+        }
+    }
+}

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/cache/hsql/CacheColumns.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/cache/hsql/CacheColumns.kt
@@ -1,4 +1,4 @@
-package io.github.inductiveautomation.kindling.cache
+package io.github.inductiveautomation.kindling.cache.hsql
 
 import io.github.inductiveautomation.kindling.utils.ColumnList
 import org.jdesktop.swingx.renderer.DefaultTableRenderer

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/cache/hsql/CacheEntry.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/cache/hsql/CacheEntry.kt
@@ -1,4 +1,4 @@
-package io.github.inductiveautomation.kindling.cache
+package io.github.inductiveautomation.kindling.cache.hsql
 
 import java.sql.Timestamp
 

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/cache/hsql/CacheView.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/cache/hsql/CacheView.kt
@@ -1,16 +1,15 @@
-package io.github.inductiveautomation.kindling.cache
+package io.github.inductiveautomation.kindling.cache.hsql
 
 import com.formdev.flatlaf.extras.FlatSVGIcon
 import com.formdev.flatlaf.extras.components.FlatPopupMenu
 import com.jidesoft.swing.JideButton
+import io.github.inductiveautomation.kindling.cache.CacheViewer
 import io.github.inductiveautomation.kindling.core.Detail
 import io.github.inductiveautomation.kindling.core.DetailsPane
-import io.github.inductiveautomation.kindling.core.Tool
 import io.github.inductiveautomation.kindling.core.ToolOpeningException
 import io.github.inductiveautomation.kindling.core.ToolPanel
 import io.github.inductiveautomation.kindling.utils.Action
 import io.github.inductiveautomation.kindling.utils.EDT_SCOPE
-import io.github.inductiveautomation.kindling.utils.FileFilter
 import io.github.inductiveautomation.kindling.utils.FlatScrollPane
 import io.github.inductiveautomation.kindling.utils.HorizontalSplitPane
 import io.github.inductiveautomation.kindling.utils.ReifiedJXTable
@@ -296,7 +295,7 @@ class CacheView(path: Path) : ToolPanel() {
                             try {
                                 val deserialized = bytes.deserializeStoreAndForward()
                                 deserialized.toDetail()
-                            } catch (e: Exception) {
+                            } catch (_: Exception) {
                                 // It's not serialized with a class in the public API, or some other problem;
                                 // give up, and try to just dump the serialized data in a friendlier format
                                 val serializationDumper = deser.SerializationDumper(bytes)
@@ -337,13 +336,3 @@ class CacheView(path: Path) : ToolPanel() {
     }
 }
 
-data object CacheViewer : Tool {
-    override val serialKey = "sf-cache"
-    override val title = "Store & Forward Cache"
-    override val description = "S&F Cache (.data, .script, .zip)"
-    override val icon = FlatSVGIcon("icons/bx-data.svg")
-    internal val extensions = arrayOf("data", "script", "zip")
-    override val filter = FileFilter(description, *extensions)
-
-    override fun open(path: Path): ToolPanel = CacheView(path)
-}

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/cache/hsql/CacheView.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/cache/hsql/CacheView.kt
@@ -295,7 +295,8 @@ class CacheView(path: Path) : ToolPanel() {
                             try {
                                 val deserialized = bytes.deserializeStoreAndForward()
                                 deserialized.toDetail()
-                            } catch (_: Exception) {
+                            } catch (e: Exception) {
+                                e.printStackTrace()
                                 // It's not serialized with a class in the public API, or some other problem;
                                 // give up, and try to just dump the serialized data in a friendlier format
                                 val serializationDumper = deser.SerializationDumper(bytes)

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/cache/hsql/SchemaFilterList.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/cache/hsql/SchemaFilterList.kt
@@ -1,4 +1,4 @@
-package io.github.inductiveautomation.kindling.cache
+package io.github.inductiveautomation.kindling.cache.hsql
 
 import com.jidesoft.swing.CheckBoxList
 import io.github.inductiveautomation.kindling.utils.listCellRenderer

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/cache/hsql/SchemaModel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/cache/hsql/SchemaModel.kt
@@ -1,4 +1,4 @@
-package io.github.inductiveautomation.kindling.cache
+package io.github.inductiveautomation.kindling.cache.hsql
 
 data class SchemaRecord(
     val id: Int,

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/cache/model/AuditProfileData.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/cache/model/AuditProfileData.kt
@@ -1,12 +1,12 @@
 package io.github.inductiveautomation.kindling.cache.model
 
-import com.inductiveautomation.ignition.gateway.audit.AuditRecord
 import io.github.inductiveautomation.kindling.core.Detail
 import java.io.Serializable
+import java.util.Date
 
 @Suppress("unused")
 class AuditProfileData(
-    private val auditRecord: AuditRecord,
+    private val auditRecord: DefaultAuditRecord,
     private val insertQuery: String,
     private val parentLog: String,
 ) : Serializable {
@@ -35,5 +35,23 @@ class AuditProfileData(
     companion object {
         @JvmStatic
         private val serialVersionUID = 3037488986978918285L
+    }
+}
+
+@Suppress("unused")
+class DefaultAuditRecord(
+    val originatingContext: Int,
+    val statusCode: Int,
+    val action: String,
+    val actionTarget: String?,
+    val actionValue: String,
+    val actor: String,
+    val actorHost: String,
+    val originatingSystem: String,
+    val timestamp: Date,
+) : Serializable {
+    companion object {
+        @JvmStatic
+        private val serialVersionUID = 0x21d9a89f09913781
     }
 }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/cache/model/RemoteEvent.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/cache/model/RemoteEvent.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package io.github.inductiveautomation.kindling.cache.model
 
 import com.inductiveautomation.ignition.common.alarming.AlarmPriority
@@ -9,9 +11,9 @@ import com.inductiveautomation.ignition.gateway.alarming.journal.EventFlags.IS_C
 import com.inductiveautomation.ignition.gateway.alarming.journal.EventFlags.SHELVED_EVENT_FLAG
 import com.inductiveautomation.ignition.gateway.alarming.journal.EventFlags.SYSTEM_ACK_FLAG
 import com.inductiveautomation.ignition.gateway.alarming.journal.EventFlags.SYSTEM_EVENT_FLAG
-import com.inductiveautomation.ignition.gateway.history.DatasourceData
-import com.inductiveautomation.ignition.gateway.history.HistoricalData
-import com.inductiveautomation.ignition.gateway.history.HistoryFlavor
+import com.inductiveautomation.ignition.gateway.storeforward.data.PersistentData
+import com.inductiveautomation.ignition.gateway.storeforward.deprecated.HistoricalData
+import com.inductiveautomation.ignition.gateway.storeforward.deprecated.HistoryFlavor
 import io.github.inductiveautomation.kindling.core.Detail
 import java.io.Serial
 
@@ -25,10 +27,11 @@ class RemoteEvent(
     val eventFlags: Int = 0,
     val data: EventData? = null,
 ) : HistoricalData {
-    override fun getFlavor(): HistoryFlavor = DatasourceData.FLAVOR
+    override fun getFlavor(): HistoryFlavor = HistoryFlavor("__datasourcedata__")
     override fun getSignature(): String = "Remote Alarm Journal Event"
     override fun getDataCount(): Int = 1
     override fun getLoggerName(): String? = null
+    override fun upgrade(p0: String?): PersistentData? = null
 
     fun toDetail(): Detail {
         val details = mapOf(

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/cache/sqlite/CacheView.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/cache/sqlite/CacheView.kt
@@ -1,0 +1,178 @@
+package io.github.inductiveautomation.kindling.cache.sqlite
+
+import io.github.inductiveautomation.kindling.core.Detail
+import io.github.inductiveautomation.kindling.core.DetailsPane
+import io.github.inductiveautomation.kindling.core.ToolPanel
+import io.github.inductiveautomation.kindling.utils.FilterList
+import io.github.inductiveautomation.kindling.utils.FilterModel
+import io.github.inductiveautomation.kindling.utils.FlatScrollPane
+import io.github.inductiveautomation.kindling.utils.HorizontalSplitPane
+import io.github.inductiveautomation.kindling.utils.ReifiedJXTable
+import io.github.inductiveautomation.kindling.utils.ReifiedLabelProvider.Companion.setDefaultRenderer
+import io.github.inductiveautomation.kindling.utils.ReifiedListTableModel
+import io.github.inductiveautomation.kindling.utils.SQLiteConnection
+import io.github.inductiveautomation.kindling.utils.VerticalSplitPane
+import io.github.inductiveautomation.kindling.utils.deserializeStoreAndForward
+import io.github.inductiveautomation.kindling.utils.executeQuery
+import io.github.inductiveautomation.kindling.utils.get
+import io.github.inductiveautomation.kindling.utils.selectedRowIndices
+import io.github.inductiveautomation.kindling.utils.toDetail
+import io.github.inductiveautomation.kindling.utils.toFileSizeLabel
+import io.github.inductiveautomation.kindling.utils.toHumanReadableBinary
+import io.github.inductiveautomation.kindling.utils.toList
+import io.github.inductiveautomation.kindling.utils.transferTo
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.sql.Connection
+import kotlin.io.path.extension
+import kotlin.io.path.inputStream
+import kotlin.io.path.outputStream
+import kotlin.io.path.walk
+import org.sqlite.SQLiteConnection
+
+class CacheView private constructor(connections: List<Connection>) : ToolPanel() {
+    private val cacheData = connections.flatMap { conn ->
+        conn.executeQuery(CACHE_DATA_QUERY).toList { rs ->
+            val id: Int = rs["id"]
+
+            IdbCacheEntry(
+                id = id,
+                dataSize = rs["data_length"],
+                timestamp = rs["timestamp"],
+                attemptCount = rs["attempt_count"],
+                dataCount = rs["data_count"],
+                flavorId = rs["flavor_id"],
+                flavorName = rs["flavor"],
+                quarantineId = rs["quarantine_id"],
+                reason = rs["reason"],
+                quarantineFlavorId = rs["quarantine_flavor_id"],
+                getData = {
+                    conn.prepareStatement(GET_DATA_QUERY).run {
+                        setInt(1, id)
+                        executeQuery().toList { dataResult ->
+                            dataResult.getBytes("data")
+                        }.single()
+                    }
+                }
+            )
+        }
+    }
+
+    private val cacheTable = ReifiedJXTable(
+        ReifiedListTableModel(cacheData, IdbCacheColumns),
+    ).apply {
+        setDefaultRenderer<ByteArray>(
+            getText = {
+                if (it != null) {
+                    "${it.size.toLong().toFileSizeLabel()} BLOB"
+                } else {
+                    ""
+                }
+            },
+            getTooltip = { "Export to CSV to view full data (b64 encoded)" },
+        )
+    }
+
+    private val details = DetailsPane()
+
+    val dataFlavorFilterList = FilterList().apply {
+        setModel(
+            FilterModel(
+                cacheData.groupingBy(IdbCacheEntry::flavorName).eachCount(),
+                sortKey = { it }
+            )
+        )
+    }
+
+    override val icon = null
+
+    init {
+        name = "S&F Cache View"
+
+        add(
+            HorizontalSplitPane(
+                left = VerticalSplitPane(
+                    top = FlatScrollPane(cacheTable),
+                    bottom = details,
+                ),
+                right = FlatScrollPane(dataFlavorFilterList)
+            ),
+            "push, grow, span",
+        )
+
+        cacheTable.selectionModel.addListSelectionListener { event ->
+            if (!event.valueIsAdjusting) {
+                details.events = cacheTable.selectedRowIndices().map { index ->
+                    val modelIndex = cacheTable.convertRowIndexToModel(index)
+                    val entry = cacheTable.model[modelIndex]
+
+                    try {
+                        val deserialized = entry.data.deserializeStoreAndForward()
+                        deserialized.toDetail()
+                    } catch (_: Exception) {
+                        // It's not serialized with a class in the public API, or some other problem;
+                        // give up, and try to just dump the serialized data in a friendlier format
+                        val serializationDumper = deser.SerializationDumper(entry.data)
+
+                        Detail(
+                            title = "Serialization dump of ${entry.data.size} bytes:",
+                            body = try {
+                                serializationDumper.parseStream().lines()
+                            } catch (_: Exception) {
+                                entry.data.inputStream().use {
+                                    it.toHumanReadableBinary().split("\n")
+                                }
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val CACHE_DATA_QUERY = """
+            SELECT
+                d.id,
+                OCTET_LENGTH(d.data) as 'data_length',
+                d.timestamp,
+                d.attempt_count,
+                d.data_count,
+                d.flavor_id,
+                f.flavor,
+                d.quarantine_id,
+                q.reason,
+                q.flavor_id as 'quarantine_flavor_id'
+            FROM persistent_data d
+            LEFT JOIN persistent_flavors f ON f.id = d.flavor_id
+            LEFT JOIN quarantine_info q ON q.id = d.quarantine_id
+        """
+
+        private const val GET_DATA_QUERY = "SELECT data from persistent_data WHERE id = ?"
+
+        fun fromZip(path: Path): CacheView {
+            val connections = FileSystems.newFileSystem(path).use {  fs ->
+                val tempDir = Files.createTempDirectory("kindling")
+
+                fs.rootDirectories.first().walk().mapNotNull {
+                    if (it.extension == "idb") {
+                        val tempFile = Files.createTempFile(tempDir, "kindling", "cache")
+                        it.inputStream() transferTo tempFile.outputStream()
+                        SQLiteConnection(tempFile, journalEnabled = true)
+                    } else {
+                        null
+                    }
+                }.toList()
+            }
+
+            return CacheView(connections)
+        }
+
+        fun fromConnection(connection: Connection): CacheView {
+            return CacheView(listOf(connection))
+        }
+
+        fun fromIdb(idbPath: Path) = fromConnection(SQLiteConnection(idbPath, journalEnabled = true))
+    }
+}

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/cache/sqlite/IdbCacheColumns.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/cache/sqlite/IdbCacheColumns.kt
@@ -1,0 +1,65 @@
+package io.github.inductiveautomation.kindling.cache.sqlite
+
+import io.github.inductiveautomation.kindling.utils.ColumnList
+import io.github.inductiveautomation.kindling.utils.toFileSizeLabel
+import java.awt.Component
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import javax.swing.JTable
+import javax.swing.table.DefaultTableCellRenderer
+
+@Suppress("unused")
+object IdbCacheColumns : ColumnList<IdbCacheEntry>() {
+    val ID by column { it.id }
+    val Data by column(
+        column = {
+            cellRenderer = object : DefaultTableCellRenderer() {
+                override fun getTableCellRendererComponent(
+                    table: JTable?,
+                    value: Any?,
+                    isSelected: Boolean,
+                    hasFocus: Boolean,
+                    row: Int,
+                    column: Int
+                ): Component? {
+                    super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
+                    text = (value as Long).toFileSizeLabel()
+                    return this
+                }
+            }
+        },
+        value = IdbCacheEntry::dataSize
+    )
+    val Timestamp by column(
+        column = {
+            cellRenderer = object : DefaultTableCellRenderer() {
+                override fun getTableCellRendererComponent(
+                    table: JTable?,
+                    value: Any?,
+                    isSelected: Boolean,
+                    hasFocus: Boolean,
+                    row: Int,
+                    column: Int,
+                ): Component {
+                    super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
+
+                    val datetime = ZonedDateTime.ofInstant(value as Instant, ZoneId.systemDefault())
+                    text = datetime.format(DateTimeFormatter.RFC_1123_DATE_TIME)
+
+                    return this
+                }
+            }
+        },
+        value = {
+            Instant.ofEpochMilli(it.timestamp)
+        }
+    )
+    val AttemptCount by column("Attempt Count") { it.attemptCount }
+    val DataCount by column("Data Count") { it.dataCount }
+    val FlavorId by column("Flavor ID") { it.flavorId }
+    val FlavorName by column("Flavor Name") { it.flavorName }
+    val QuarantineId by column("Quarantine ID") { it.quarantineId }
+    val Reason by column { it.reason }
+}

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/cache/sqlite/IdbCacheEntry.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/cache/sqlite/IdbCacheEntry.kt
@@ -1,0 +1,20 @@
+package io.github.inductiveautomation.kindling.cache.sqlite
+
+data class IdbCacheEntry(
+    val id: Int,
+    val dataSize: Long,
+    val timestamp: Long,
+    val attemptCount: Int,
+    val dataCount: Int,
+    val flavorId: Int,
+    val flavorName: String,
+    val quarantineId: Int?,
+    val reason: String?,
+    val quarantineFlavorId: Int?,
+    val getData: () -> ByteArray,
+) {
+    val data by lazy {
+        println("Getting data")
+        getData()
+    }
+}

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/cache/sqlite/IdbCacheEntry.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/cache/sqlite/IdbCacheEntry.kt
@@ -14,7 +14,6 @@ data class IdbCacheEntry(
     val getData: () -> ByteArray,
 ) {
     val data by lazy {
-        println("Getting data")
         getData()
     }
 }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/idb/IdbView.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/idb/IdbView.kt
@@ -3,6 +3,7 @@ package io.github.inductiveautomation.kindling.idb
 import com.formdev.flatlaf.extras.FlatSVGIcon
 import com.formdev.flatlaf.extras.components.FlatTabbedPane
 import com.formdev.flatlaf.extras.components.FlatTabbedPane.TabType
+import io.github.inductiveautomation.kindling.cache.sqlite.CacheView
 import io.github.inductiveautomation.kindling.core.MultiTool
 import io.github.inductiveautomation.kindling.core.ToolPanel
 import io.github.inductiveautomation.kindling.idb.generic.GenericView
@@ -133,6 +134,15 @@ private enum class IdbTool {
             return SystemLogPanel(paths, logFiles)
         }
     },
+    Cache {
+        override fun supports(connections: List<IdbConnection>): Boolean {
+            return connections.all { "persistent_data" in it.tables }
+        }
+
+        override fun open(connections: List<IdbConnection>): ToolPanel {
+            return CacheView.fromConnection(connections.single().connection)
+        }
+    }
     ;
 
     open val tabName: String = name

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/idb/ImagesTab.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/idb/ImagesTab.kt
@@ -3,7 +3,7 @@ package io.github.inductiveautomation.kindling.idb
 import com.formdev.flatlaf.extras.FlatSVGIcon
 import com.github.weisj.jsvg.parser.LoaderContext
 import com.github.weisj.jsvg.parser.SVGLoader
-import com.inductiveautomation.ignition.gateway.images.ImageFormat
+import com.inductiveautomation.ignition.common.images.ImageFormat
 import com.jidesoft.comparator.AlphanumComparator
 import io.github.inductiveautomation.kindling.core.ToolPanel
 import io.github.inductiveautomation.kindling.core.ToolPanel.Companion.exportFileChooser

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/General.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/General.kt
@@ -1,6 +1,7 @@
 package io.github.inductiveautomation.kindling.utils
 
 import com.jidesoft.swing.CheckBoxListSelectionModel
+import java.io.ByteArrayOutputStream
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -10,6 +11,7 @@ import org.slf4j.LoggerFactory
 import java.io.InputStream
 import java.io.OutputStream
 import java.util.Properties
+import java.util.zip.GZIPInputStream
 import kotlin.math.log2
 import kotlin.math.pow
 import kotlin.reflect.KProperty
@@ -188,4 +190,22 @@ fun String.containsInOrder(pattern: String, ignoreCase: Boolean): Boolean {
         }
     }
     return patternIndex == pattern.length
+}
+
+fun ByteArray.unzip(): ByteArray {
+    if (size <= 2) return this
+
+    val firstByte = this[0].toInt()
+    val secondByte = this[1].toInt()
+
+    val header = (firstByte and 0xFF) or ((secondByte and 0xFF) shl 8)
+
+    if (header != GZIPInputStream.GZIP_MAGIC) {
+        return this
+    }
+
+    val byteOutput = ByteArrayOutputStream()
+    GZIPInputStream(inputStream()) transferTo byteOutput
+
+    return byteOutput.toByteArray()
 }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/Sql.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/Sql.kt
@@ -82,11 +82,12 @@ inline fun <reified T> sqliteCoercion(raw: Any?): T {
 fun SQLiteConnection(
     path: Path,
     readOnly: Boolean = true,
+    journalEnabled: Boolean = false
 ): SQLiteConnection {
     return SQLiteDataSource().apply {
         url = "jdbc:sqlite:file:$path"
         setReadOnly(readOnly)
-        setJournalMode("OFF")
+        if (!journalEnabled) setJournalMode("OFF")
         setSynchronous("OFF")
     }.connection as SQLiteConnection
 }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/StoreAndForward.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/StoreAndForward.kt
@@ -1,13 +1,16 @@
+@file:Suppress("DEPRECATION")
+
 package io.github.inductiveautomation.kindling.utils
 
-import com.inductiveautomation.ignition.gateway.history.BasicHistoricalRecord
-import com.inductiveautomation.ignition.gateway.history.ScanclassHistorySet
+import com.inductiveautomation.ignition.gateway.storeforward.deprecated.BasicHistoricalRecord
+import com.inductiveautomation.ignition.gateway.storeforward.deprecated.ScanclassHistorySet
 import io.github.inductiveautomation.kindling.cache.AliasingObjectInputStream
 import io.github.inductiveautomation.kindling.cache.model.AbstractDataset
 import io.github.inductiveautomation.kindling.cache.model.AlarmJournalData
 import io.github.inductiveautomation.kindling.cache.model.AlarmJournalSFGroup
 import io.github.inductiveautomation.kindling.cache.model.AuditProfileData
 import io.github.inductiveautomation.kindling.cache.model.BasicDataset
+import io.github.inductiveautomation.kindling.cache.model.DefaultAuditRecord
 import io.github.inductiveautomation.kindling.cache.model.RemoteEvent
 import io.github.inductiveautomation.kindling.cache.model.ScriptedSFData
 import io.github.inductiveautomation.kindling.core.Detail
@@ -59,6 +62,18 @@ fun ByteArray.deserializeStoreAndForward(): Serializable {
         put("com.inductiveautomation.ignition.gateway.alarming.journal.remote.RemoteEvent", RemoteEvent::class.java)
         put("com.inductiveautomation.ignition.gateway.alarming.journal.DatabaseAlarmJournal\$AlarmJournalSFData", AlarmJournalData::class.java)
         put("com.inductiveautomation.ignition.gateway.alarming.journal.DatabaseAlarmJournal\$AlarmJournalSFGroup", AlarmJournalSFGroup::class.java)
+        put(
+            "com.inductiveautomation.ignition.gateway.history.PackedHistoricalQualifiedValue",
+            com.inductiveautomation.ignition.gateway.storeforward.deprecated.PackedHistoricalQualifiedValue::class.java,
+        )
+        put(
+            "com.inductiveautomation.ignition.gateway.sqltags.model.BasicScanclassHistorySet",
+            com.inductiveautomation.ignition.gateway.storeforward.deprecated.BasicScanclassHistorySet::class.java,
+        )
+        put(
+            "com.inductiveautomation.ignition.gateway.audit.DefaultAuditRecord",
+            DefaultAuditRecord::class.java,
+        )
     }.readObject() as Serializable
 }
 

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/StoreAndForward.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/StoreAndForward.kt
@@ -2,6 +2,10 @@
 
 package io.github.inductiveautomation.kindling.utils
 
+import com.google.protobuf.GeneratedMessageV3
+import com.inductiveautomation.ignition.gateway.alarming.journal.encoding.AlarmJournalProto
+import com.inductiveautomation.ignition.gateway.history.encoding.GenericObjectProto
+import com.inductiveautomation.ignition.gateway.history.encoding.HistoryDataProto
 import com.inductiveautomation.ignition.gateway.storeforward.deprecated.BasicHistoricalRecord
 import com.inductiveautomation.ignition.gateway.storeforward.deprecated.ScanclassHistorySet
 import io.github.inductiveautomation.kindling.cache.AliasingObjectInputStream
@@ -14,6 +18,7 @@ import io.github.inductiveautomation.kindling.cache.model.DefaultAuditRecord
 import io.github.inductiveautomation.kindling.cache.model.RemoteEvent
 import io.github.inductiveautomation.kindling.cache.model.ScriptedSFData
 import io.github.inductiveautomation.kindling.core.Detail
+import java.io.DataInputStream
 import java.io.Serializable
 
 const val TRANSACTION_GROUP_DATA = "Transaction Group Data"
@@ -56,12 +61,12 @@ fun Serializable.toDetail(): Detail = when (this) {
 fun ByteArray.deserializeStoreAndForward(): Serializable {
     return AliasingObjectInputStream(inputStream()) {
         put("com.inductiveautomation.ignition.gateway.audit.AuditProfileData", AuditProfileData::class.java)
-        put("com.inductiveautomation.ignition.gateway.script.ialabs.IALabsDatasourceFunctions\$QuerySFData", ScriptedSFData::class.java)
+        put($$"com.inductiveautomation.ignition.gateway.script.ialabs.IALabsDatasourceFunctions$QuerySFData", ScriptedSFData::class.java)
         put("com.inductiveautomation.ignition.common.AbstractDataset", AbstractDataset::class.java)
         put("com.inductiveautomation.ignition.common.BasicDataset", BasicDataset::class.java)
         put("com.inductiveautomation.ignition.gateway.alarming.journal.remote.RemoteEvent", RemoteEvent::class.java)
-        put("com.inductiveautomation.ignition.gateway.alarming.journal.DatabaseAlarmJournal\$AlarmJournalSFData", AlarmJournalData::class.java)
-        put("com.inductiveautomation.ignition.gateway.alarming.journal.DatabaseAlarmJournal\$AlarmJournalSFGroup", AlarmJournalSFGroup::class.java)
+        put($$"com.inductiveautomation.ignition.gateway.alarming.journal.DatabaseAlarmJournal$AlarmJournalSFData", AlarmJournalData::class.java)
+        put($$"com.inductiveautomation.ignition.gateway.alarming.journal.DatabaseAlarmJournal$AlarmJournalSFGroup", AlarmJournalSFGroup::class.java)
         put(
             "com.inductiveautomation.ignition.gateway.history.PackedHistoricalQualifiedValue",
             com.inductiveautomation.ignition.gateway.storeforward.deprecated.PackedHistoricalQualifiedValue::class.java,
@@ -118,5 +123,79 @@ fun BasicHistoricalRecord.toDetail(): Detail {
         details = mapOf(
             "quoteColumnNames" to quoteColumnNames().toString(),
         ),
+    )
+}
+
+// 8.3
+
+fun ByteArray.deserializeStoreAndForward(flavor: String): List<GeneratedMessageV3> {
+    val parseFunction: (ByteArray) -> GeneratedMessageV3 = when (flavor) {
+        "history_set" -> {
+            HistoryDataProto.HistorySetPB::parseFrom
+        }
+        "alarm_journal_event" -> {
+            AlarmJournalProto.JournalEventPB::parseFrom
+        }
+        else -> {
+            GenericObjectProto.GenericObjectPB::parseFrom
+        }
+    }
+
+    return buildList {
+        DataInputStream(inputStream()).use { dis ->
+            while (dis.available() > 0) {
+                val length = dis.readInt()
+                val objectBytes = ByteArray(length)
+                dis.readFully(objectBytes)
+
+                val byteData = objectBytes.unzip()
+
+                add(parseFunction(byteData))
+            }
+        }
+    }
+}
+
+fun GeneratedMessageV3.toDetail() = when (this) {
+    is HistoryDataProto.HistorySetPB -> toDetail()
+    is AlarmJournalProto.JournalEventPB -> toDetail()
+    is GenericObjectProto.GenericObjectPB -> toDetail()
+    else -> error("Unknown class: ${this::class.java.name}")
+}
+
+fun HistoryDataProto.HistorySetPB.toDetail(): Detail {
+    return Detail(
+        title = "Tag History Set of $tagValuesCount tag values",
+        body = buildList<String> {
+            add("System: $systemName")
+            add("Provider: $providerName")
+            add("Tag Group: $tagGroupName")
+            add("Tag Values:")
+            addAll(
+                tagValuesList.map {
+                    "Path: ${it.tagPath}\n${it.value}"
+                }
+            )
+        }
+    )
+}
+
+fun AlarmJournalProto.JournalEventPB.toDetail(): Detail {
+    return Detail(
+        title = "Alarm Journal Event",
+        body = listOf(
+            "Source: $source",
+            "Display Path: $displayPath",
+            "UUID: $uuid",
+            "System Type: $systemType",
+            "Target Journal: $targetJournal",
+        )
+    )
+}
+
+fun GenericObjectProto.GenericObjectPB.toDetail(): Detail {
+    return Detail(
+        title = "Generic Protobuf Object",
+        body = listOf(this.toString()),
     )
 }


### PR DESCRIPTION
This includes a few changes which I did test, though problems might creep up related to backwards compatibility (Hopefully not).

### Changes
- Changed Ignition dependencies to version 8.3.0
- Made them transitive. (I couldn't get Gradle to download them if they weren't, for some reason)
- Changed old S&F class alias references to use the now deprecated ones. (See `StoreAndForward.kt`
- Ensured that the other things which use the Ignition SDK still work (I test the Images IDB Viewer and Alarm Cache Viewer)
- 8.1 S&F Cache Viewer still works the same
- Created `hsql` and `sqlite` packages under the Cache viewer tool's package

### Usage
There are 3 ways you can open an 8.3 S&F Cache:
- Open a single .idb file with the IDB Tool
- Open a single .idb file with the S&F Tool
- Open a .zip containing however many files with the S&F tool. (The zip opening process does not care about how the files are structured, and simply picks out all the .idb files from it)
