### PR TITLE
Fixed Date Picker Evaluation of Timestamps

### DIFF
--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/TimePanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/TimePanel.kt
@@ -293,7 +293,7 @@ internal class TimePanel<T : LogEvent>(
     }
 }
 
-private fun ZonedDateTime.toDate(): Date? = toLocalDate()
+private fun ZonedDateTime.toDate(): Date = toLocalDate()
     .atStartOfDay(zone)
     .toInstant()
     .let(Date::from)
@@ -306,7 +306,7 @@ private fun JXDatePicker.setDate(zonedDateTime: ZonedDateTime) {
     date = zonedDateTime.toDate()
 }
 
-class DateTimeSelector(
+private class DateTimeSelector(
     var defaultValue: Instant,
     initialRange: ClosedRange<Instant>,
 ) : JPanel(MigLayout("ins 0")) {
@@ -334,8 +334,8 @@ class DateTimeSelector(
                 // adjust calendar from java.time to java.util weekday numbering
                 firstDayOfWeek = WeekFields.of(Locale.getDefault()).firstDayOfWeek.value % 7 + 1
 
-                lowerBound = Date.from(range.start)
-                upperBound = Date.from(range.endInclusive)
+                lowerBound = range.start.atZone(Timezone.Default.zoneId).toDate()
+                upperBound = range.endInclusive.atZone(Timezone.Default.zoneId).toDate()
             }
             linkPanel = JPanel() // can't be null or BasicDatePickerUI throws an NPE on theme change
 
@@ -365,7 +365,7 @@ class DateTimeSelector(
                     localDate,
                     timeSelector.localTime,
                     Timezone.Default.zoneId,
-                ).toInstant() ?: defaultValue
+                ).toInstant()
             }
         }
         set(value) {
@@ -403,7 +403,7 @@ class DateTimeSelector(
     }
 }
 
-class TimeSelector : JPanel(MigLayout("fill, ins 0")) {
+private class TimeSelector : JPanel(MigLayout("fill, ins 0")) {
     private val hourSelector = timePartSpinner(HOUR_OF_DAY, "00", 10)
     private val minuteSelector = timePartSpinner(MINUTE_OF_HOUR, ":00", 6)
     private val secondSelector = timePartSpinner(SECOND_OF_MINUTE, ":00", 6)


### PR DESCRIPTION
The JXDatePickers in the time panel for the log filters seems to run into issues, especially when the time zone preference is updated. The main issues include: 

- The date does not update in the filter when time zones are changed.
- Dates were incorrect in the time filter when the logs were sorted. 
- The reset button would use the original start and end date when clicked.
- The date picker ranges would not update and would often times be wrong forbidding the user from being able to use the full and accurate date range. 

https://youtrack.ia.local/issue/ZD-2815/Log-Time-Filter-resets-incorrectly-when-non-local-timezone-is-being-used

**Changes**
- Added a changeListener to  Timezone.Default to update necessary fields in TimePanel when the time zone is changed.
- Split JXDatePicker.localDate into separate functions in order to allow accept zoned date times as the passed argument. Previously there as a loss of data when converting to a local date before entering the function. 
-  Created ZonedDateTime.toDate() to remove redundant code 


**Testing**
- Tested with both system and wrapper logs. 
- Changed time zones, sorted data, reset filters.