### PR TITLE
GAN File Filter

### DIFF
--- a/src/main/kotlin/io/github/inductiveautomation/kindling/gatewaynetwork/GatewayNetworkViewer.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/gatewaynetwork/GatewayNetworkViewer.kt
@@ -9,8 +9,12 @@ import io.github.inductiveautomation.kindling.utils.Action
 import io.github.inductiveautomation.kindling.utils.FileFilter
 import io.github.inductiveautomation.kindling.utils.FlatScrollPane
 import io.github.inductiveautomation.kindling.utils.transferTo
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.serializer
 import java.awt.Desktop
 import java.net.URI
@@ -21,6 +25,7 @@ import javax.swing.JButton
 import javax.swing.JOptionPane
 import javax.swing.JTextArea
 import kotlin.io.path.createTempDirectory
+import kotlin.io.path.inputStream
 import kotlin.io.path.name
 import kotlin.io.path.outputStream
 import kotlin.io.path.useLines
@@ -157,5 +162,13 @@ data object GatewayNetworkTool : ClipboardTool {
             tooltip = path.toString(),
             json = diagram,
         )
+    }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    override val filter: FileFilter = FileFilter(description) { path ->
+        (path.name.endsWith("json") || path.name.endsWith("txt")) &&
+            runCatching {
+                (Json.decodeFromStream<JsonElement>(path.inputStream()) as? JsonObject)?.containsKey("connections") == true
+            }.getOrDefault(false)
     }
 }


### PR DESCRIPTION
# Description
Attempting to open a thread dump in the zip tool opens the file in the generic text viewer with json syntax highlights when it should open in the thread dump tool. Kindling is attempting to open it as a GAN diagram so the GAN diagram tools file filter needed to be expanded upon. 

## Changes
- [x] Added override to file filter for the GAN tool so that it checks that the file in question ends with json and contains the json property 'connections' which is unique to the GAN json.  
https://youtrack.ia.local/issue/ZD-2947/gateway-network-live-diagram.json-file-should-use-Gateway-Network-Diagram-tool-in-zip-bundle

# Testing
- [x] Tested using diagnostic bundle. 
- [x] Tested with 7.9 thread dump (rearranging order temporarily broke thread dumps)
- [x] Tested with liveDiagram and gateway-network-live-diagram files.
