### PR TITLE
multi checkbox shift selection support

### DIFF
--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/LogPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/LogPanel.kt
@@ -35,8 +35,6 @@ import net.miginfocom.swing.MigLayout
 import org.jdesktop.swingx.JXSearchField
 import org.jdesktop.swingx.table.ColumnControlButton.COLUMN_CONTROL_MARKER
 import java.awt.BorderLayout
-import java.awt.event.MouseAdapter
-import java.awt.event.MouseEvent
 import java.util.Vector
 import javax.swing.BorderFactory
 import javax.swing.Icon
@@ -201,8 +199,8 @@ sealed class LogPanel<T : LogEvent>(
 
             // If a log checkbox is checked while holding shift it checks all between previous check
             // to align with Java Swing highlighting features
-            addMouseListener(object : MouseAdapter() {
-                override fun mouseClicked(e: MouseEvent) {
+            addMouseListener(object : java.awt.event.MouseAdapter() {
+                override fun mouseClicked(e: java.awt.event.MouseEvent) {
                     val viewCol = columnAtPoint(e.point)
                     val viewRow = rowAtPoint(e.point)
                     if (viewRow == -1 || viewCol == -1) return

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/LogPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/LogPanel.kt
@@ -35,6 +35,8 @@ import net.miginfocom.swing.MigLayout
 import org.jdesktop.swingx.JXSearchField
 import org.jdesktop.swingx.table.ColumnControlButton.COLUMN_CONTROL_MARKER
 import java.awt.BorderLayout
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
 import java.util.Vector
 import javax.swing.BorderFactory
 import javax.swing.Icon
@@ -197,10 +199,9 @@ sealed class LogPanel<T : LogEvent>(
         table.apply {
             var lastMarkedRow: Int? = null
 
-            // If a log checkbox is checked while holding shift it checks all between previous check
-            // to align with Java Swing highlighting features
-            addMouseListener(object : java.awt.event.MouseAdapter() {
-                override fun mouseClicked(e: java.awt.event.MouseEvent) {
+            // Handle shift clicks in the mark column as multi-select events
+            addMouseListener(object : MouseAdapter() {
+                override fun mouseClicked(e: MouseEvent) {
                     val viewCol = columnAtPoint(e.point)
                     val viewRow = rowAtPoint(e.point)
                     if (viewRow == -1 || viewCol == -1) return

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/LogPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/LogPanel.kt
@@ -35,6 +35,8 @@ import net.miginfocom.swing.MigLayout
 import org.jdesktop.swingx.JXSearchField
 import org.jdesktop.swingx.table.ColumnControlButton.COLUMN_CONTROL_MARKER
 import java.awt.BorderLayout
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
 import java.util.Vector
 import javax.swing.BorderFactory
 import javax.swing.Icon
@@ -199,8 +201,8 @@ sealed class LogPanel<T : LogEvent>(
 
             // If a log checkbox is checked while holding shift it checks all between previous check
             // to align with Java Swing highlighting features
-            addMouseListener(object : java.awt.event.MouseAdapter() {
-                override fun mouseClicked(e: java.awt.event.MouseEvent) {
+            addMouseListener(object : MouseAdapter() {
+                override fun mouseClicked(e: MouseEvent) {
                     val viewCol = columnAtPoint(e.point)
                     val viewRow = rowAtPoint(e.point)
                     if (viewRow == -1 || viewCol == -1) return

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/LogPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/LogPanel.kt
@@ -212,15 +212,12 @@ sealed class LogPanel<T : LogEvent>(
 
                     if (e.isShiftDown && lastMarkedRow != null) {
                         val anchor = lastMarkedRow!!
-                        val from = minOf(anchor, modelRow) // range selection works in both directions
-                        val to = maxOf(anchor, modelRow)
+                        val range = minOf(anchor, modelRow)..maxOf(anchor, modelRow)
                         val newValue = model.data[modelRow].marked
-                        var idx = 0
-                        model.markRows { _ ->
-                            val inRange = idx in from..to
-                            idx++
-                            if (inRange) newValue else null
+                        model.markRows { i, _ ->
+                            newValue.takeIf {i in range }
                         }
+                        lastMarkedRow = null
                     } else {
                         lastMarkedRow = modelRow
                     }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/LogPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/LogPanel.kt
@@ -215,7 +215,7 @@ sealed class LogPanel<T : LogEvent>(
                         val range = minOf(anchor, modelRow)..maxOf(anchor, modelRow)
                         val newValue = model.data[modelRow].marked
                         model.markRows { i, _ ->
-                            newValue.takeIf {i in range }
+                            newValue.takeIf { i in range }
                         }
                         lastMarkedRow = null
                     } else {

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/LogPanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/LogPanel.kt
@@ -195,6 +195,38 @@ sealed class LogPanel<T : LogEvent>(
         add(footer, "growx, spanx 2")
 
         table.apply {
+            var lastMarkedRow: Int? = null
+
+            // If a log checkbox is checked while holding shift it checks all between previous check
+            // to align with Java Swing highlighting features
+            addMouseListener(object : java.awt.event.MouseAdapter() {
+                override fun mouseClicked(e: java.awt.event.MouseEvent) {
+                    val viewCol = columnAtPoint(e.point)
+                    val viewRow = rowAtPoint(e.point)
+                    if (viewRow == -1 || viewCol == -1) return
+
+                    val modelCol = convertColumnIndexToModel(viewCol)
+                    if (modelCol != model.markIndex) return
+
+                    val modelRow = convertRowIndexToModel(viewRow)
+
+                    if (e.isShiftDown && lastMarkedRow != null) {
+                        val anchor = lastMarkedRow!!
+                        val from = minOf(anchor, modelRow) // range selection works in both directions
+                        val to = maxOf(anchor, modelRow)
+                        val newValue = model.data[modelRow].marked
+                        var idx = 0
+                        model.markRows { _ ->
+                            val inRange = idx in from..to
+                            idx++
+                            if (inRange) newValue else null
+                        }
+                    } else {
+                        lastMarkedRow = modelRow
+                    }
+                }
+            })
+
             selectionModel.addListSelectionListener { selectionEvent ->
                 if (!selectionEvent.valueIsAdjusting) {
                     selectionModel.updateDetails()

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/TableModel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/TableModel.kt
@@ -45,7 +45,7 @@ class LogsModel<T : LogEvent>(
         var lastIndex = -1
 
         for ((rowIndex, event) in data.withIndex()) {
-            val shouldMark = predicate(rowIndex,event) ?: continue
+            val shouldMark = predicate(rowIndex, event) ?: continue
             if (firstIndex == -1) {
                 firstIndex = rowIndex
             }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/TableModel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/TableModel.kt
@@ -44,8 +44,8 @@ class LogsModel<T : LogEvent>(
         var firstIndex = -1
         var lastIndex = -1
 
-        for ((rowIndex, event) in data.withIndex()) {
-            val shouldMark = predicate(rowIndex, event) ?: continue
+        data.forEachIndexed { rowIndex, event ->
+            val shouldMark = predicate(rowIndex, event) ?: return@forEachIndexed
             if (firstIndex == -1) {
                 firstIndex = rowIndex
             }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/TableModel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/TableModel.kt
@@ -36,12 +36,16 @@ class LogsModel<T : LogEvent>(
      * Update marks in the model, efficiently.
      * Return true to set marked, false to clear a mark, or null to bypass the row.
      */
-    fun markRows(predicate: (T) -> Boolean?) {
+    fun markRows(predicate: (event: T) -> Boolean?) {
+        markRows { _, event -> predicate(event) }
+    }
+
+    fun markRows(predicate: (i: Int, event: T) -> Boolean?) {
         var firstIndex = -1
         var lastIndex = -1
 
         for ((rowIndex, event) in data.withIndex()) {
-            val shouldMark = predicate(event) ?: continue
+            val shouldMark = predicate(rowIndex,event) ?: continue
             if (firstIndex == -1) {
                 firstIndex = rowIndex
             }


### PR DESCRIPTION
PR for: https://github.com/inductiveautomation/kindling/issues/335

### UX point to note
When you select the first log line and then `shift + click` another one, Swing highlights these lines on `mouseDown` and this implementation highlights them on `mouseUp`.
I personally think this is the best approach because if you misclick, checking all the boxes on mouseDown is annoying. The downside is because we wait until mouseUp even if you click quickly there is still a very small delay that lags behind the row highlighting so I thought I would point it out for this reason