### PR TITLE
Make metrics and generic IDB viewers respect timezone preferences

### DIFF
--- a/src/main/kotlin/io/github/inductiveautomation/kindling/idb/generic/GenericView.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/idb/generic/GenericView.kt
@@ -25,8 +25,8 @@ import org.fife.ui.rsyntaxtextarea.SyntaxConstants
 import org.fife.ui.rtextarea.RTextScrollPane
 import java.awt.event.KeyEvent
 import java.sql.Connection
-import java.sql.Date
 import java.sql.JDBCType
+import java.sql.Timestamp
 import javax.swing.Icon
 import javax.swing.JButton
 import javax.swing.JMenuItem
@@ -86,7 +86,9 @@ class GenericView(connection: Connection) : ToolPanel("ins 0, fill, hidemode 3")
                         val types = List(columnCount) { i ->
                             val isTimestamp = names[i].containsInOrder("tsmp", true)
                             if (isTimestamp) {
-                                Date::class.java
+                                // Use Timestamp (not java.sql.Date) so full time-of-day is preserved
+                                // when formatting with the user's timezone preference.
+                                Timestamp::class.java
                             } else {
                                 val sqlType = resultSet.metaData.getColumnType(i + 1)
                                 val jdbcType = JDBCType.valueOf(sqlType)
@@ -99,7 +101,7 @@ class GenericView(connection: Connection) : ToolPanel("ins 0, fill, hidemode 3")
                                 val value = resultSet.getObject(i + 1)
                                 when {
                                     types[i] == Boolean::class.javaObjectType -> value == 1
-                                    types[i] == Date::class.java && value is Number -> Date(value.toLong())
+                                    types[i] == Timestamp::class.java && value is Number -> Timestamp(value.toLong())
                                     else -> value
                                 }
                             }

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/idb/metrics/MetricsView.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/idb/metrics/MetricsView.kt
@@ -1,5 +1,6 @@
 package io.github.inductiveautomation.kindling.idb.metrics
 
+import io.github.inductiveautomation.kindling.core.Timezone
 import io.github.inductiveautomation.kindling.core.ToolPanel
 import io.github.inductiveautomation.kindling.utils.EDT_SCOPE
 import io.github.inductiveautomation.kindling.utils.FlatScrollPane
@@ -10,7 +11,9 @@ import kotlinx.coroutines.launch
 import net.miginfocom.swing.MigLayout
 import java.sql.Connection
 import javax.swing.Icon
+import javax.swing.JLabel
 import javax.swing.JPanel
+import javax.swing.SwingConstants
 
 class MetricsView(connection: Connection) : ToolPanel("ins 0, fill, hidemode 3") {
     @Suppress("SqlResolve")
@@ -60,6 +63,11 @@ class MetricsView(connection: Connection) : ToolPanel("ins 0, fill, hidemode 3")
             MetricCard(metric, metricData)
         }
 
+    private val timezoneLabel = JLabel(timezoneLabelText(), SwingConstants.CENTER).apply {
+        putClientProperty("FlatLaf.styleClass", "small")
+        toolTipText = "Timestamps are displayed using the General > Timezone preference"
+    }
+
     private val cardPanel =
         JPanel(MigLayout("wrap 2, fillx, gap 20, hidemode 3, ins 6")).apply {
             for (card in metricCards) {
@@ -67,12 +75,23 @@ class MetricsView(connection: Connection) : ToolPanel("ins 0, fill, hidemode 3")
             }
         }
 
+    private val metricsPanel = JPanel(MigLayout("ins 0, fill")).apply {
+        add(timezoneLabel, "growx, wrap")
+        add(FlatScrollPane(cardPanel), "push, grow")
+    }
+
     init {
         add(FlatScrollPane(metricTree), "grow, w 200::20%")
-        add(FlatScrollPane(cardPanel), "push, grow, span")
+        add(metricsPanel, "push, grow, span")
 
         metricTree.checkBoxTreeSelectionModel.addTreeSelectionListener { updateData() }
+
+        Timezone.Default.addChangeListener {
+            timezoneLabel.text = timezoneLabelText()
+        }
     }
+
+    private fun timezoneLabelText(): String = "Timezone: ${Timezone.Default.zoneId.id}"
 
     private fun updateData() {
         BACKGROUND.launch {

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/idb/metrics/Sparkline.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/idb/metrics/Sparkline.kt
@@ -5,6 +5,7 @@ import io.github.inductiveautomation.kindling.core.Theme.Companion.theme
 import io.github.inductiveautomation.kindling.core.Timezone
 import org.jfree.chart.ChartFactory
 import org.jfree.chart.JFreeChart
+import org.jfree.chart.axis.DateAxis
 import org.jfree.chart.axis.NumberAxis
 import org.jfree.chart.ui.RectangleInsets
 import org.jfree.data.time.FixedMillisecond
@@ -12,6 +13,7 @@ import org.jfree.data.time.TimeSeries
 import org.jfree.data.time.TimeSeriesCollection
 import java.text.NumberFormat
 import java.time.Instant
+import java.util.TimeZone
 
 fun sparkline(data: List<MetricData>, formatter: NumberFormat): JFreeChart = ChartFactory.createTimeSeriesChart(
     /* title = */
@@ -41,17 +43,20 @@ fun sparkline(data: List<MetricData>, formatter: NumberFormat): JFreeChart = Cha
             isPositiveArrowVisible = true
             (this as NumberAxis).numberFormatOverride = formatter
         }
-        val updateTooltipGenerator = {
+
+        fun applyTimezone() {
+            (domainAxis as? DateAxis)?.timeZone = TimeZone.getTimeZone(Timezone.Default.zoneId)
             renderer.setDefaultToolTipGenerator { dataset, series, item ->
                 val time = Instant.ofEpochMilli(dataset.getXValue(series, item).toLong())
                 "${Timezone.Default.format(time)} - ${formatter.format(dataset.getYValue(series, item))}"
             }
         }
 
-        updateTooltipGenerator()
+        applyTimezone()
 
         Timezone.Default.addChangeListener {
-            updateTooltipGenerator()
+            applyTimezone()
+            fireChartChanged()
         }
 
         isDomainGridlinesVisible = false

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/ReifiedJXTable.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/ReifiedJXTable.kt
@@ -1,6 +1,7 @@
 package io.github.inductiveautomation.kindling.utils
 
 import com.formdev.flatlaf.extras.FlatSVGIcon
+import io.github.inductiveautomation.kindling.core.Timezone
 import io.github.inductiveautomation.kindling.utils.ReifiedLabelProvider.Companion.setDefaultRenderer
 import org.jdesktop.swingx.JXTable
 import org.jdesktop.swingx.JXTableHeader
@@ -10,7 +11,6 @@ import org.jdesktop.swingx.sort.SortController
 import org.jdesktop.swingx.table.ColumnControlButton
 import java.awt.Color
 import java.awt.event.MouseEvent
-import java.text.SimpleDateFormat
 import java.util.Date
 import javax.swing.JComponent
 import javax.swing.SortOrder
@@ -55,6 +55,10 @@ class ReifiedJXTable<T : TableModel>(
 
         packLater()
         actionMap.remove("find")
+
+        Timezone.Default.addChangeListener {
+            repaint()
+        }
     }
 
     override fun createDefaultTableHeader(): JTableHeader? = object : JXTableHeader(columnModel) {
@@ -77,9 +81,8 @@ class ReifiedJXTable<T : TableModel>(
             getText = { it },
             getTooltip = { it },
         )
-        val format = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
         setDefaultRenderer<Date>(
-            getText = { it?.let(format::format) },
+            getText = { it?.let(Timezone.Default::format) },
         )
     }
 


### PR DESCRIPTION
## Summary

Fixes #300 by finishing timezone-preference support for the metrics and generic IDB viewers (on top of the global preference from #321).

### Changes
- **Generic IDB / shared tables** (`ReifiedJXTable`): Date columns are formatted with `Timezone.Default` instead of a system-default `SimpleDateFormat`, and tables repaint when the preference changes. This also covers QuestDB result tables that share the same renderer.
- **Generic IDB** (`GenericView`): Columns whose names contain `tsmp` are now instantiated as `java.sql.Timestamp` (not `java.sql.Date`) so full time-of-day is preserved when formatting in the preferred zone.
- **Metrics view** (`MetricsView`): Adds a live `Timezone: <zone-id>` label above the metric cards so it's clear which zone is in use.
- **Sparklines** (`Sparkline`): Domain `DateAxis` timezone tracks the preference (tooltips already did).

### How tested
- `./gradlew compileKotlin test` — BUILD SUCCESSFUL (existing tests pass)
- `./gradlew spotlessCheck` — BUILD SUCCESSFUL

### AI disclosure
This contribution was developed with assistance from an AI coding agent (Grok/Cursor). Changes were reviewed and validated by running the project's Gradle compile, test, and Spotless checks.