### PR TITLE
Improved datetime selector

### DIFF
--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/TimePanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/TimePanel.kt
@@ -1,15 +1,13 @@
 package io.github.inductiveautomation.kindling.log
 
 import com.formdev.flatlaf.extras.FlatSVGIcon
-import com.formdev.flatlaf.extras.components.FlatButton
 import io.github.inductiveautomation.kindling.core.FilterChangeListener
 import io.github.inductiveautomation.kindling.core.FilterPanel
-import io.github.inductiveautomation.kindling.core.Kindling.Preferences.UI.Theme
 import io.github.inductiveautomation.kindling.core.Timezone
 import io.github.inductiveautomation.kindling.utils.Action
 import io.github.inductiveautomation.kindling.utils.Column
 import io.github.inductiveautomation.kindling.utils.ColumnList
-import io.github.inductiveautomation.kindling.utils.EmptyBorder
+import io.github.inductiveautomation.kindling.utils.DateTimeSelector
 import io.github.inductiveautomation.kindling.utils.FileFilterResponsive
 import io.github.inductiveautomation.kindling.utils.FlatScrollPane
 import io.github.inductiveautomation.kindling.utils.ReifiedJXTable
@@ -17,42 +15,21 @@ import io.github.inductiveautomation.kindling.utils.ReifiedListTableModel
 import io.github.inductiveautomation.kindling.utils.getAll
 import io.github.inductiveautomation.kindling.utils.getAncestorOfClass
 import net.miginfocom.swing.MigLayout
-import org.jdesktop.swingx.JXDatePicker
 import org.jdesktop.swingx.renderer.DefaultTableRenderer
-import java.awt.Cursor
 import java.awt.EventQueue
-import java.awt.Insets
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import java.time.Instant
 import java.time.LocalDate
-import java.time.LocalTime
-import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
-import java.time.temporal.ChronoField
-import java.time.temporal.ChronoField.HOUR_OF_DAY
-import java.time.temporal.ChronoField.MILLI_OF_SECOND
-import java.time.temporal.ChronoField.MINUTE_OF_HOUR
-import java.time.temporal.ChronoField.SECOND_OF_MINUTE
 import java.time.temporal.ChronoUnit
-import java.time.temporal.WeekFields
-import java.util.Date
-import java.util.Locale
 import javax.swing.JButton
-import javax.swing.JComponent
 import javax.swing.JLabel
 import javax.swing.JPanel
 import javax.swing.JPopupMenu
 import javax.swing.JSeparator
-import javax.swing.JSpinner
 import javax.swing.ListSelectionModel
 import javax.swing.SortOrder
-import javax.swing.SpinnerModel
-import javax.swing.SpinnerNumberModel
-import javax.swing.SwingConstants
-import javax.swing.UIManager
-import javax.swing.border.LineBorder
-import kotlin.math.absoluteValue
 
 internal class TimePanel<T : LogEvent>(
     data: List<T>,
@@ -66,8 +43,8 @@ internal class TimePanel<T : LogEvent>(
     private var coveredRange: ClosedRange<Instant> = lowerBound..upperBound
     private var totalCurrentRange = coveredRange
 
-    private val startSelector = DateTimeSelector(lowerBound, totalCurrentRange)
-    private val endSelector = DateTimeSelector(upperBound, totalCurrentRange)
+    private val startSelector = DateTimeSelector(lowerBound, totalCurrentRange, "Start Time")
+    private val endSelector = DateTimeSelector(upperBound, totalCurrentRange, "End Time")
 
     private val denseMinutesTable =
         ReifiedJXTable(
@@ -168,13 +145,7 @@ internal class TimePanel<T : LogEvent>(
     override val component =
         JPanel(MigLayout("ins 2 0, fill, wrap 1")).apply {
             add(startSelector, "pushx, growx")
-            add(
-                JLabel("To").apply {
-                    horizontalAlignment = SwingConstants.CENTER
-                },
-                "align center, growx",
-            )
-            add(endSelector, "pushx, growx")
+            add(endSelector, "pushx, growx, gaptop 4")
 
             add(
                 JSeparator(JSeparator.HORIZONTAL),
@@ -202,11 +173,20 @@ internal class TimePanel<T : LogEvent>(
 
     init {
         startSelector.addPropertyChangeListener("time") {
+            // push the other bound along rather than letting the two cross
+            if (startSelector.time > endSelector.time) {
+                endSelector.time = startSelector.time
+            }
             updateCoveredRange()
         }
         endSelector.addPropertyChangeListener("time") {
+            if (endSelector.time < startSelector.time) {
+                startSelector.time = endSelector.time
+            }
             updateCoveredRange()
         }
+
+        updateHighlightedDates(data)
 
         Timezone.Default.addChangeListener {
             lowerBound = data.minOf { it.timestamp }
@@ -214,8 +194,16 @@ internal class TimePanel<T : LogEvent>(
             totalCurrentRange = lowerBound..upperBound
             startSelector.range = totalCurrentRange
             endSelector.range = totalCurrentRange
+            updateHighlightedDates(data)
             reset()
         }
+    }
+
+    /** Flags the days which contain events in both selectors' calendars. */
+    private fun updateHighlightedDates(data: List<T>) {
+        val daysWithData = data.mapTo(mutableSetOf()) { LocalDate.ofInstant(it.timestamp, Timezone.Default.zoneId) }
+        startSelector.highlightedDates = daysWithData
+        endSelector.highlightedDates = daysWithData
     }
 
     override fun isFilterApplied(): Boolean = coveredRange != totalCurrentRange
@@ -291,228 +279,6 @@ internal class TimePanel<T : LogEvent>(
         endSelector.time = upperBound
         updateCoveredRange()
     }
-}
-
-private fun ZonedDateTime.toDate(): Date = toLocalDate()
-    .atStartOfDay(zone)
-    .toInstant()
-    .let(Date::from)
-
-private fun JXDatePicker.getLocalDate(): LocalDate? = date?.toInstant()
-    ?.let { LocalDate.ofInstant(it, timeZone.toZoneId()) }
-
-private fun JXDatePicker.setDate(zonedDateTime: ZonedDateTime) {
-    timeZone = java.util.TimeZone.getTimeZone(zonedDateTime.zone)
-    date = zonedDateTime.toDate()
-}
-
-private class DateTimeSelector(
-    var defaultValue: Instant,
-    initialRange: ClosedRange<Instant>,
-) : JPanel(MigLayout("ins 0")) {
-    var range: ClosedRange<Instant> = initialRange
-        set(value) {
-            field = value
-            datePicker.monthView.apply {
-                lowerBound = value.start
-                    .atZone(Timezone.Default.zoneId)
-                    .toDate()
-                upperBound = value.endInclusive
-                    .atZone(Timezone.Default.zoneId)
-                    .toDate()
-            }
-        }
-
-    private val initialZonedTime: ZonedDateTime
-        get() = defaultValue.atZone(Timezone.Default.zoneId)
-
-    private val datePicker =
-        JXDatePicker().apply {
-            setDate(initialZonedTime)
-            editor.horizontalAlignment = SwingConstants.CENTER
-            monthView.apply {
-                // adjust calendar from java.time to java.util weekday numbering
-                firstDayOfWeek = WeekFields.of(Locale.getDefault()).firstDayOfWeek.value % 7 + 1
-
-                lowerBound = range.start.atZone(Timezone.Default.zoneId).toDate()
-                upperBound = range.endInclusive.atZone(Timezone.Default.zoneId).toDate()
-            }
-            linkPanel = JPanel() // can't be null or BasicDatePickerUI throws an NPE on theme change
-
-            addActionListener {
-                if (date == null) { // out of range selection sets null in JXDatePicker - we'll be nicer and reset
-                    setDate(initialZonedTime)
-                } else {
-                    firePropertyChange("time", null, time)
-                }
-            }
-        }
-
-    private val timeSelector = TimeSelector().apply {
-        localTime = initialZonedTime.toLocalTime()
-        addPropertyChangeListener("localTime") {
-            firePropertyChange("time", null, time)
-        }
-    }
-
-    var time: Instant
-        get() {
-            val localDate = datePicker.getLocalDate()
-            return if (localDate == null) {
-                defaultValue
-            } else {
-                ZonedDateTime.of(
-                    localDate,
-                    timeSelector.localTime,
-                    Timezone.Default.zoneId,
-                ).toInstant()
-            }
-        }
-        set(value) {
-            val zonedDateTime = value.atZone(Timezone.Default.zoneId)
-            datePicker.setDate(zonedDateTime)
-            timeSelector.localTime = zonedDateTime.toLocalTime()
-        }
-
-    init {
-        add(datePicker, "growx, spanx, pushx, wrap")
-        add(timeSelector, "growx, spanx, pushx, wrap")
-
-        for (amount in listOf(-30L, -15, -5, -1, 1L, 5, 15, 30)) {
-            add(
-                FlatButton().apply {
-                    action = Action(
-                        name = "%+d".format(amount),
-                        description = buildString {
-                            append(if (amount > 0) "Add" else "Subtract")
-                            append(" ")
-                            append(amount.absoluteValue)
-                            append(" minute")
-                            if (amount.absoluteValue > 1) {
-                                append("s")
-                            }
-                        },
-                    ) {
-                        time = time.plusSeconds(amount * 60)
-                    }
-                    margin = Insets(1, 1, 1, 1)
-                },
-                "w 12.5%, sgx",
-            )
-        }
-    }
-}
-
-private class TimeSelector : JPanel(MigLayout("fill, ins 0")) {
-    private val hourSelector = timePartSpinner(HOUR_OF_DAY, "00", 10)
-    private val minuteSelector = timePartSpinner(MINUTE_OF_HOUR, ":00", 6)
-    private val secondSelector = timePartSpinner(SECOND_OF_MINUTE, ":00", 6)
-    private val milliSelector = timePartSpinner(MILLI_OF_SECOND, "'.'000", 1)
-
-    private fun timePartSpinner(
-        field: ChronoField,
-        pattern: String,
-        pixelsPerValueChange: Int,
-    ) = TimePartSpinner(ChronoSpinnerModel(field, pattern), pixelsPerValueChange).apply {
-        addChangeListener {
-            firePropertyChange("localTime", null, localTime)
-        }
-    }
-
-    init {
-        background = UIManager.getColor("ComboBox.background")
-        border = LineBorder(UIManager.getColor("Button.borderColor"))
-        add(hourSelector, "wmin 45, growx")
-        add(minuteSelector, "wmin 45, growx")
-        add(secondSelector, "wmin 45, growx")
-        add(milliSelector, "wmin 55, growx")
-
-        Theme.addChangeListener {
-            background = UIManager.getColor("ComboBox.background")
-            border = LineBorder(UIManager.getColor("Button.borderColor"))
-        }
-    }
-
-    var localTime: LocalTime
-        get() =
-            LocalTime.of(
-                hourSelector.value.toInt(),
-                minuteSelector.value.toInt(),
-                secondSelector.value.toInt(),
-                // milli-of-second to nano-of-second
-                (milliSelector.value * 1_000_000).toInt(),
-            )
-        set(value) {
-            hourSelector.value = value.hour.toLong()
-            minuteSelector.value = value.minute.toLong()
-            secondSelector.value = value.second.toLong()
-            // milli-of-second to nano-of-second
-            milliSelector.value = (value.nano / 1_000_000).toLong()
-        }
-}
-
-private class TimePartSpinner(
-    model: ChronoSpinnerModel,
-    pixelsPerValueChange: Int,
-) : JSpinner(model) {
-    var isSelection = true
-
-    private val dragListener =
-        object : MouseAdapter() {
-            private var previousY = 0
-
-            override fun mouseDragged(e: MouseEvent) {
-                if (e.y < 0 || e.y > height) {
-                    val deltaY = previousY - (e.y / pixelsPerValueChange)
-                    var currentValue = value + deltaY
-                    if (deltaY < 0 && previousY == 0) {
-                        currentValue += height
-                    }
-                    value = currentValue.coerceIn(0, model.maximum)
-                }
-                previousY = e.y / pixelsPerValueChange
-            }
-
-            override fun mouseReleased(e: MouseEvent) {
-                isSelection = true
-                previousY = 0
-                fireStateChanged()
-            }
-
-            override fun mousePressed(e: MouseEvent) {
-                isSelection = false
-            }
-        }
-
-    override fun createEditor(model: SpinnerModel): JComponent {
-        check(model is ChronoSpinnerModel)
-        return NumberEditor(this, model.pattern).apply {
-            textField.apply {
-                border = EmptyBorder()
-                cursor = Cursor.getPredefinedCursor(Cursor.S_RESIZE_CURSOR)
-            }
-        }
-    }
-
-    init {
-        border = EmptyBorder()
-        isOpaque = false
-        (editor as DefaultEditor).textField.apply {
-            addMouseMotionListener(dragListener)
-            addMouseListener(dragListener)
-        }
-    }
-
-    override fun getValue(): Long = super.getValue() as Long
-
-    override fun getModel(): ChronoSpinnerModel = super.getModel() as ChronoSpinnerModel
-}
-
-private class ChronoSpinnerModel(
-    field: ChronoField,
-    val pattern: String,
-) : SpinnerNumberModel(0L, field.range().minimum, field.range().maximum, 1L) {
-    override fun getMaximum(): Long = super.getMaximum() as Long
 }
 
 private data class DenseTime(

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/log/TimePanel.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/log/TimePanel.kt
@@ -45,7 +45,7 @@ internal class TimePanel<T : LogEvent>(
 
     private val startSelector = DateTimeSelector(lowerBound, totalCurrentRange, "Start Time")
     private val endSelector = DateTimeSelector(upperBound, totalCurrentRange, "End Time")
-
+    private var pushingBounds = false
     private val denseMinutesTable =
         ReifiedJXTable(
             ReifiedListTableModel(
@@ -173,15 +173,27 @@ internal class TimePanel<T : LogEvent>(
 
     init {
         startSelector.addPropertyChangeListener("time") {
+            if (pushingBounds) return@addPropertyChangeListener
             // push the other bound along rather than letting the two cross
             if (startSelector.time > endSelector.time) {
-                endSelector.time = startSelector.time
+                pushingBounds = true
+                try {
+                    endSelector.time = startSelector.time
+                } finally {
+                    pushingBounds = false
+                }
             }
             updateCoveredRange()
         }
         endSelector.addPropertyChangeListener("time") {
+            if (pushingBounds) return@addPropertyChangeListener
             if (endSelector.time < startSelector.time) {
-                startSelector.time = endSelector.time
+                pushingBounds = true
+                try {
+                    startSelector.time = endSelector.time
+                } finally {
+                    pushingBounds = false
+                }
             }
             updateCoveredRange()
         }
@@ -234,10 +246,9 @@ internal class TimePanel<T : LogEvent>(
         )
 
         startSelector.range = totalCurrentRange
-        startSelector.defaultValue = lowerBound
-
         endSelector.range = totalCurrentRange
-        endSelector.defaultValue = upperBound
+
+        updateHighlightedDates(data)
 
         if (!isFilterApplied) {
             reset()

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/DateTimeSelector.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/DateTimeSelector.kt
@@ -60,9 +60,6 @@ class DateTimeSelector(
     private val zoneId: ZoneId
         get() = Timezone.Default.zoneId
 
-    /** The value [reset] returns to. */
-    var defaultValue: Instant = initialValue
-
     /** Times outside this range are dimmed in the popup's list. */
     var range: ClosedRange<Instant> = initialRange
         set(value) {
@@ -242,10 +239,6 @@ class DateTimeSelector(
         }
     }
 
-    fun reset() {
-        time = defaultValue
-    }
-
     // Actions are inlined into their buttons since each is only used in one place
     private fun footer() = JPanel(MigLayout("ins 0, fillx, wrap 4, gapx 2, gapy 2")).apply {
         add(
@@ -273,7 +266,7 @@ class DateTimeSelector(
             "sgx jump, growx",
         )
 
-        for (amount in listOf(-30L, -15, -5, -1, 1L, 5, 15, 30)) {
+        for (amount in listOf(-30L, -15, -5, -1, 30L, 15, 5, 1)) {
             add(
                 footerButton(
                     name = "%+d".format(amount),
@@ -410,7 +403,7 @@ class DateTimeSelector(
         val END_OF_DAY: LocalTime = LocalTime.MAX.truncatedTo(ChronoUnit.MILLIS)
 
         val DISPLAY_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss.SSS")
-        val TIME_HEADER_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSS")
+        val TIME_HEADER_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss:SSS")
         val TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
         val DATE_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("uuuu-MM-dd")
 

--- a/src/main/kotlin/io/github/inductiveautomation/kindling/utils/DateTimeSelector.kt
+++ b/src/main/kotlin/io/github/inductiveautomation/kindling/utils/DateTimeSelector.kt
@@ -1,0 +1,425 @@
+package io.github.inductiveautomation.kindling.utils
+
+import com.formdev.flatlaf.FlatClientProperties
+import com.formdev.flatlaf.extras.FlatSVGIcon
+import com.formdev.flatlaf.extras.components.FlatButton
+import com.formdev.flatlaf.extras.components.FlatTextField
+import io.github.inductiveautomation.kindling.core.Kindling.Preferences.UI.Theme
+import io.github.inductiveautomation.kindling.core.Timezone
+import net.miginfocom.swing.MigLayout
+import org.jdesktop.swingx.JXMonthView
+import org.jdesktop.swingx.calendar.DateSelectionModel
+import java.awt.Dimension
+import java.awt.EventQueue
+import java.awt.Insets
+import java.awt.Point
+import java.awt.event.FocusAdapter
+import java.awt.event.FocusEvent
+import java.awt.event.KeyEvent
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+import java.time.temporal.WeekFields
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import javax.swing.JComponent
+import javax.swing.JLabel
+import javax.swing.JList
+import javax.swing.JPanel
+import javax.swing.JPopupMenu
+import javax.swing.KeyStroke
+import javax.swing.ListSelectionModel
+import javax.swing.ScrollPaneConstants
+import javax.swing.SwingConstants
+import javax.swing.SwingUtilities
+import javax.swing.UIManager
+import javax.swing.event.PopupMenuEvent
+import javax.swing.event.PopupMenuListener
+import kotlin.math.absoluteValue
+
+/**
+ * A timestamp field backed by a popup containing a calendar and a list of times, in increments of [step].
+ * Values are clamped into [range]; changes fire a `time` property change.
+ */
+class DateTimeSelector(
+    initialValue: Instant,
+    initialRange: ClosedRange<Instant>,
+    title: String? = null,
+    private val step: Duration = Duration.ofMinutes(5),
+) : JPanel(MigLayout("ins 0, fillx, wrap 1, gapy 1")) {
+    private val zoneId: ZoneId
+        get() = Timezone.Default.zoneId
+
+    /** The value [reset] returns to. */
+    var defaultValue: Instant = initialValue
+
+    /** Times outside this range are dimmed in the popup's list. */
+    var range: ClosedRange<Instant> = initialRange
+        set(value) {
+            field = value
+            time = time.coerceIn(value)
+            updateDisplay()
+        }
+
+    var time: Instant = initialValue.coerceIn(initialRange)
+        set(value) {
+            val coerced = value.coerceIn(range)
+            val old = field
+            if (coerced == old) return
+            field = coerced
+            updateDisplay()
+            firePropertyChange("time", old, coerced)
+        }
+
+    /** Days to flag in the calendar. */
+    var highlightedDates: Set<LocalDate> = emptySet()
+        set(value) {
+            field = value
+            val dates = value.map { Date.from(it.atStartOfDay(zoneId).toInstant()) }
+            monthView.setFlaggedDates(*dates.toTypedArray())
+        }
+
+    // set while updateDisplay pushes values into the calendar and the time list
+    private var adjusting = false
+
+    // the popup isn't in the frame's component tree, so it doesn't get theme updates on its own
+    private var themeChangedWhileHidden = false
+
+    private var lastHiddenAt = 0L
+
+    private val timesOfDay: List<LocalTime> = run {
+        require(!step.isZero && !step.isNegative && step <= Duration.ofDays(1)) {
+            "step must be a positive duration of at most one day, was $step"
+        }
+        val nanos = step.toNanos()
+        List((Duration.ofDays(1).toNanos() / nanos).toInt()) { LocalTime.ofNanoOfDay(it * nanos) }
+    }
+
+    private val monthView = JXMonthView().apply {
+        isTraversable = true
+        selectionMode = DateSelectionModel.SelectionMode.SINGLE_SELECTION
+        // adjust calendar from java.time to java.util weekday numbering
+        firstDayOfWeek = WeekFields.of(Locale.getDefault()).firstDayOfWeek.value % 7 + 1
+        boxPaddingX = 4
+        boxPaddingY = 3
+
+        selectionModel.addDateSelectionListener {
+            if (adjusting) return@addDateSelectionListener
+            val selectedDay = selectionDate ?: return@addDateSelectionListener
+            time = ZonedDateTime.of(
+                LocalDate.ofInstant(selectedDay.toInstant(), zoneId),
+                time.atZone(zoneId).toLocalTime(),
+                zoneId,
+            ).toInstant()
+        }
+    }
+
+    private val timeList = JList(timesOfDay.toTypedArray()).apply {
+        selectionMode = ListSelectionModel.SINGLE_SELECTION
+        cellRenderer = listCellRenderer<LocalTime> { _, value, _, _, _ ->
+            horizontalAlignment = SwingConstants.CENTER
+            text = TIME_FORMAT.format(value)
+            if (!isSelectable(value)) {
+                foreground = UIManager.getColor("Label.disabledForeground")
+            }
+        }
+
+        addListSelectionListener { event ->
+            // don't fire while dragging through the list
+            if (adjusting || event.valueIsAdjusting) return@addListSelectionListener
+            val selectedTime = selectedValue ?: return@addListSelectionListener
+            time = ZonedDateTime.of(time.atZone(zoneId).toLocalDate(), selectedTime, zoneId).toInstant()
+        }
+    }
+
+    private val timeScrollPane = FlatScrollPane(timeList) {
+        horizontalScrollBarPolicy = ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER
+        verticalScrollBar.unitIncrement = 16
+    }
+
+    private val timeHeader = JLabel("", SwingConstants.CENTER)
+
+    private val editor = FlatTextField().apply {
+        horizontalAlignment = SwingConstants.CENTER
+        toolTipText = "Type a timestamp, scroll to nudge it, or press Down for the calendar"
+
+        trailingComponent = FlatButton().apply {
+            icon = FlatSVGIcon("icons/bx-time-five.svg").derive(14, 14)
+            buttonType = FlatButton.ButtonType.toolBarButton
+            toolTipText = "Pick a date and time"
+            addActionListener { togglePopup() }
+        }
+
+        // Enter commits; losing focus reverts
+        addActionListener { commitEditor(revertIfInvalid = false) }
+        addFocusListener(
+            object : FocusAdapter() {
+                override fun focusLost(e: FocusEvent) = commitEditor(revertIfInvalid = true)
+            },
+        )
+
+        addMouseListener(
+            object : MouseAdapter() {
+                override fun mouseClicked(e: MouseEvent) {
+                    if (e.clickCount >= 2) {
+                        showPopup()
+                    }
+                }
+            },
+        )
+
+        addMouseWheelListener { e ->
+            if (isFocusOwner) {
+                val unit = when {
+                    e.isShiftDown -> ChronoUnit.HOURS
+                    e.isControlDown -> ChronoUnit.SECONDS
+                    else -> ChronoUnit.MINUTES
+                }
+                // wheel rotation is negative when scrolling up
+                time = time.minus(e.wheelRotation.toLong(), unit)
+                e.consume()
+            } else {
+                parent?.dispatchEvent(SwingUtilities.convertMouseEvent(this, e, parent))
+            }
+        }
+
+        getInputMap(JComponent.WHEN_FOCUSED).put(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, 0), SHOW_POPUP)
+        actionMap.put(SHOW_POPUP, Action { showPopup() })
+    }
+
+    private val popup = JPopupMenu().apply {
+        layout = MigLayout("ins 4, fillx, gapx 6")
+
+        add(monthView, "aligny top")
+        add(
+            JPanel(MigLayout("ins 0, fill, wrap 1, gapy 2")).apply {
+                add(timeHeader, "growx")
+                add(timeScrollPane, "grow, push")
+            },
+            "aligny top, growy",
+        )
+        add(footer(), "newline, spanx, growx, gaptop 4")
+
+        addPopupMenuListener(
+            object : PopupMenuListener {
+                override fun popupMenuWillBecomeVisible(e: PopupMenuEvent) = Unit
+
+                override fun popupMenuWillBecomeInvisible(e: PopupMenuEvent) {
+                    lastHiddenAt = System.currentTimeMillis()
+                }
+
+                override fun popupMenuCanceled(e: PopupMenuEvent) = Unit
+            },
+        )
+    }
+
+    init {
+        if (title != null) {
+            add(JLabel(title, SwingConstants.CENTER), "growx")
+        }
+        add(editor, "growx, pushx")
+
+        applyColors()
+        updateDisplay()
+
+        Timezone.Default.addChangeListener {
+            updateDisplay()
+        }
+
+        Theme.addChangeListener {
+            applyColors()
+            themeChangedWhileHidden = true
+        }
+    }
+
+    fun reset() {
+        time = defaultValue
+    }
+
+    // Actions are inlined into their buttons since each is only used in one place
+    private fun footer() = JPanel(MigLayout("ins 0, fillx, wrap 4, gapx 2, gapy 2")).apply {
+        add(
+            footerButton("Earliest", "Jump to the start of the available data") {
+                time = range.start
+            },
+            "sgx jump, growx",
+        )
+        add(
+            footerButton("Day Start", "Jump to midnight of the selected day") {
+                time = time.atZone(zoneId).toLocalDate().atStartOfDay(zoneId).toInstant()
+            },
+            "sgx jump, growx",
+        )
+        add(
+            footerButton("Day End", "Jump to the last millisecond of the selected day") {
+                time = time.atZone(zoneId).toLocalDate().atTime(END_OF_DAY).atZone(zoneId).toInstant()
+            },
+            "sgx jump, growx",
+        )
+        add(
+            footerButton("Latest", "Jump to the end of the available data") {
+                time = range.endInclusive
+            },
+            "sgx jump, growx",
+        )
+
+        for (amount in listOf(-30L, -15, -5, -1, 1L, 5, 15, 30)) {
+            add(
+                footerButton(
+                    name = "%+d".format(amount),
+                    description = buildString {
+                        append(if (amount > 0) "Add" else "Subtract")
+                        append(" ")
+                        append(amount.absoluteValue)
+                        append(" minute")
+                        if (amount.absoluteValue > 1) {
+                            append("s")
+                        }
+                    },
+                ) {
+                    time = time.plusSeconds(amount * 60)
+                },
+                "sgx nudge, growx",
+            )
+        }
+    }
+
+    private fun footerButton(name: String, description: String, onClick: () -> Unit) = FlatButton().apply {
+        action = Action(name = name, description = description) { onClick() }
+        margin = Insets(1, 1, 1, 1)
+    }
+
+    private fun isSelectable(localTime: LocalTime): Boolean {
+        val candidate = ZonedDateTime.of(time.atZone(zoneId).toLocalDate(), localTime, zoneId)
+        return candidate.toInstant() in range
+    }
+
+    private fun applyColors() {
+        UIManager.getColor("Actions.Yellow")?.let { weekend ->
+            monthView.setDayForeground(Calendar.SATURDAY, weekend)
+            monthView.setDayForeground(Calendar.SUNDAY, weekend)
+        }
+        UIManager.getColor("Actions.Blue")?.let { monthView.flaggedDayForeground = it }
+        UIManager.getColor("Label.foreground")?.let { monthView.monthStringForeground = it }
+        UIManager.getColor("Panel.background")?.let {
+            monthView.monthStringBackground = it
+            monthView.background = it
+        }
+        UIManager.getColor("List.selectionBackground")?.let { monthView.selectionBackground = it }
+        UIManager.getColor("List.selectionForeground")?.let { monthView.selectionForeground = it }
+    }
+
+    private fun updateDisplay() {
+        adjusting = true
+        try {
+            val zoned = time.atZone(zoneId)
+            editor.text = DISPLAY_FORMAT.format(zoned)
+            editor.outline = null
+
+            val startOfDay = Date.from(zoned.toLocalDate().atStartOfDay(zoneId).toInstant())
+            monthView.timeZone = TimeZone.getTimeZone(zoneId)
+            monthView.selectionDate = startOfDay
+            monthView.ensureDateVisible(startOfDay)
+
+            timeHeader.text = TIME_HEADER_FORMAT.format(zoned)
+            timeList.selectedIndex = timesOfDay.indexOfLast { it <= zoned.toLocalTime() }
+            timeList.repaint()
+        } finally {
+            adjusting = false
+        }
+    }
+
+    private fun commitEditor(revertIfInvalid: Boolean) {
+        val parsed = parse(editor.text)
+        if (parsed == null && !revertIfInvalid) {
+            editor.outline = FlatClientProperties.OUTLINE_ERROR
+            return
+        }
+        if (parsed != null) {
+            time = parsed
+        }
+        // the value may have been clamped or rejected
+        updateDisplay()
+    }
+
+    private fun parse(text: String): Instant? {
+        val trimmed = text.trim()
+        for (format in DATE_TIME_FORMATS) {
+            val parsed = runCatching { LocalDateTime.parse(trimmed, format) }.getOrNull()
+            if (parsed != null) {
+                return parsed.atZone(zoneId).toInstant()
+            }
+        }
+        return runCatching { LocalDate.parse(trimmed, DATE_FORMAT) }
+            .getOrNull()
+            ?.atStartOfDay(zoneId)
+            ?.toInstant()
+    }
+
+    private fun togglePopup() {
+        // the popup is already hidden by the time the button fires, so don't reopen it right away
+        if (System.currentTimeMillis() - lastHiddenAt > POPUP_REOPEN_DELAY) {
+            showPopup()
+        }
+    }
+
+    private fun showPopup() {
+        if (popup.isVisible) return
+
+        if (themeChangedWhileHidden) {
+            SwingUtilities.updateComponentTreeUI(popup)
+            applyColors()
+            themeChangedWhileHidden = false
+        }
+
+        updateDisplay()
+        timeScrollPane.preferredSize = Dimension(
+            TIME_COLUMN_WIDTH,
+            (monthView.preferredSize.height - timeHeader.preferredSize.height).coerceAtLeast(MIN_TIME_LIST_HEIGHT),
+        )
+
+        popup.show(this, 0, height)
+        EventQueue.invokeLater(::centerTimeListOnSelection)
+    }
+
+    private fun centerTimeListOnSelection() {
+        val index = timeList.selectedIndex
+        if (index < 0) return
+        val cell = timeList.getCellBounds(index, index) ?: return
+        val viewport = timeScrollPane.viewport
+        val maxY = (timeList.height - viewport.height).coerceAtLeast(0)
+        viewport.viewPosition = Point(0, (cell.y + cell.height / 2 - viewport.height / 2).coerceIn(0, maxY))
+    }
+
+    private companion object {
+        const val SHOW_POPUP = "showDateTimePopup"
+        const val POPUP_REOPEN_DELAY = 150L
+        const val TIME_COLUMN_WIDTH = 88
+        const val MIN_TIME_LIST_HEIGHT = 120
+
+        val END_OF_DAY: LocalTime = LocalTime.MAX.truncatedTo(ChronoUnit.MILLIS)
+
+        val DISPLAY_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss.SSS")
+        val TIME_HEADER_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss.SSS")
+        val TIME_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+        val DATE_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("uuuu-MM-dd")
+
+        val DATE_TIME_FORMATS: List<DateTimeFormatter> = listOf(
+            "uuuu-MM-dd HH:mm:ss.SSS",
+            // the format used elsewhere in Kindling, so pasted values work
+            "uuuu-MM-dd HH:mm:ss:SSS",
+            "uuuu-MM-dd HH:mm:ss",
+            "uuuu-MM-dd HH:mm",
+        ).map(DateTimeFormatter::ofPattern)
+    }
+}


### PR DESCRIPTION
The time filter's start and end fields pair a `JXDatePicker` with three spinners for
hour, minute, and second, so setting a bound means clicking through a cluster of small
arrow buttons, and the field still never shows the milliseconds that log events carry.
This replaces that stack with a single reusable `DateTimeSelector` in `utils/`: one
field showing the full timestamp, plus a popup where a scrollable list of times does
most of what the spinner buttons used to, alongside a calendar and a few jump and nudge
buttons. Days containing events are flagged in the calendar, Start and End can no longer
cross, and the field parses the `uuuu-MM-dd HH:mm:ss:SSS` format used elsewhere in
Kindling, so a timestamp copied from the log table pastes straight in.

**Changes**
- Added `utils/DateTimeSelector.kt`.
- Removed `DateTimeSelector`, `TimeSelector`, `TimePartSpinner`, `ChronoSpinnerModel` and
  `ZonedDateTime.toDate()` from `TimePanel.kt`.
- `setModelData` now refreshes the flagged days, so the calendar follows the file filter.
- #341's timezone fix still holds: the selector reads `Timezone.Default.zoneId` at each
  use rather than caching it, and re-renders when the preference changes.

**Testing**
- `./gradlew build` on JDK 21.
- Wrapper and system logs, timezone changes, file filter changes, theme changes.

**Note**
Picking from the time list zeroes seconds and milliseconds, since it steps in five minute
increments. Typing and scrolling keep full precision. Happy to change that if you would
rather the list preserve them.


<img width="390" height="313" alt="image" src="https://github.com/user-attachments/assets/f56ee976-905a-4557-badf-7fa7fc0b593a" />
